### PR TITLE
only run tests if chrome is installed

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,12 @@ export VERSION="SNAPSHOT-$GITREV"
 npm install --no-save
 npm run compile
 npm run lint
-npm test
+
+# running karma tests require chrome
+if [ -n "$(which chrome)" ]
+  then
+    npm test
+fi
 
 if [ $# -eq 0 ]
   then


### PR DESCRIPTION
Per https://github.com/georchestra/mapstore2-georchestra/issues/3#issuecomment-537822925 - otherwise chrome should be added to build requirements but that's a bit too much imo.

With that, i'm able to produce `web/target/GeOrchestra.war`