### PR TITLE
#98 Fixed tutorial position. Removed GUEST/ADMIN indicator

### DIFF
--- a/js/components/User.jsx
+++ b/js/components/User.jsx
@@ -7,10 +7,14 @@
  */
 import React from "react";
 import loadingState from "@mapstore/components/misc/enhancers/loadingState";
-const UserInfo = ({user, error}) => <span>{error && "GUEST" || user.role}</span>;
-const LoadingUser = loadingState(({ user, error }) => !user && !error)(UserInfo);
+import { compose, branch, renderNothing } from 'recompose';
+
+const UserInfo = ({user, error}) => <span >{error && "GUEST" || user.role}</span>;
+const LoadingUser = compose(
+    loadingState(({ user, error }) => !user && !error),
+)(UserInfo);
 const User = ({className, user, error, ...props}) => {
     return <div className={className}><LoadingUser user={user} error={error} {...props} /></div>;
 };
 
-export default User;
+export default branch(({ showUser = false }) => !showUser, renderNothing)(User);

--- a/js/plugins/Header.jsx
+++ b/js/plugins/Header.jsx
@@ -10,7 +10,10 @@ import { createPlugin } from "@mapstore/utils/PluginsUtils";
 
 const Header = ({page = "mapstore"}) => {
     useEffect(() => {
-        document.getElementById("georchestra-header").src = "/header/?active=" + page;
+        const header = document.getElementById("georchestra-header");
+        if (header) {
+            header.src = "/header/?active=" + page;
+        }
     }, [page]);
     return null;
 };

--- a/themes/default/georchestra.less
+++ b/themes/default/georchestra.less
@@ -7,6 +7,10 @@
     }
 }
 
+.joyride .joyride-overlay {
+    position: fixed;
+}
+
 #georchestra-notallowed {
     position: absolute;
     width: 100%;


### PR DESCRIPTION
Fixed tutorial setting tutorial overlay position to`fixed`.
Make also USER indicator not visible by default, (can be enabled via configuration, for testing purposes)