### PR TITLE
#104: externalized configuration files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,10 @@ RUN if [ "$TOMCAT_EXTRAS" = false ]; then \
 COPY docker/*.war "${CATALINA_BASE}/webapps/"
 
 # Geostore externalization template. Disabled by default
-COPY docker/geostore-datasource-ovr.properties "${CATALINA_BASE}/conf/"
-ARG GEOSTORE_OVR_OPT=""
-ENV JAVA_OPTS="${JAVA_OPTS} ${GEOSTORE_OVR_OPT}"
+# COPY docker/geostore-datasource-ovr.properties "${CATALINA_BASE}/conf/"
+# ARG GEOSTORE_OVR_OPT=""
+ARG GEORCHESTRA_DATADIR_OPT="-Dgeorchestra.datadir=/etc/georchestra"
+ENV JAVA_OPTS="${JAVA_OPTS} ${GEORCHESTRA_DATADIR_OPT}"
 
 # Set variable to better handle terminal commands
 ENV TERM xterm

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -13,31 +13,33 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
 
     <dependencies>
-        <!-- ================================================================ -->
-        <!-- JACKSON                                                          -->
-        <!-- ================================================================ -->
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.1</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson.databind-version}</version>
-        </dependency>
+			<groupId>org.mortbay.jetty</groupId>
+			<artifactId>servlet-api-2.5</artifactId>
+			<version>6.1.14</version>
+		</dependency>
         <!-- ================================================================ -->
         <!-- SPRING                                                           -->
         <!-- ================================================================ -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
+            <version>3.0.5.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
+            <version>3.0.5.RELEASE</version>
         </dependency>
         <!-- <dependency> -->
         <!-- <groupId>org.springframework</groupId> -->
@@ -46,10 +48,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-webmvc</artifactId>
+            <version>3.0.5.RELEASE</version>
         </dependency>
         <!-- =========================================================== -->
         <!-- LOGGING                                                     -->
@@ -57,10 +56,12 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
+            <version>1.2.16</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.2</version>
         </dependency>
         <!-- <dependency> -->
         <!-- <groupId>org.slf4j</groupId> -->
@@ -69,11 +70,14 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+            <version>1.7.2</version>
         </dependency>
         <!-- JUnit -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <version>4.8.1</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/backend/src/main/java/it/geosolutions/georchestra/ConfigLoader.java
+++ b/backend/src/main/java/it/geosolutions/georchestra/ConfigLoader.java
@@ -1,0 +1,54 @@
+package it.geosolutions.georchestra;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.commons.io.IOUtils;
+import org.apache.log4j.Logger;
+
+public class ConfigLoader extends HttpServlet{
+    
+    private String[] configLocations = new String[] {"localConfig.json"};
+    ServletContext ctx;
+    Logger LOGGER = Logger.getLogger(ConfigLoader.class);
+    
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+        super.init(config);
+        ctx = config.getServletContext();
+        String location = config.getInitParameter("configLocation");
+        if (location == null) {
+            LOGGER.warn("no configLocation parameter specified, using default localConfig.json");
+        } else {
+            configLocations = location.split(",");
+        }
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException {
+        for(String configLocation : configLocations) {
+            File configFile = new File(configLocation);
+            if (!configFile.exists() && !configFile.isAbsolute()) {
+                configFile = new File(ctx.getRealPath(configLocation));
+            }
+            if (configFile.exists()) {
+                // use the first existing file in the list
+                try (FileReader reader = new FileReader(configFile); Writer writer = new OutputStreamWriter(resp.getOutputStream())) { 
+                    IOUtils.copy(reader, writer);
+                    return;
+                }
+            }
+        }
+        resp.setStatus(HttpServletResponse.SC_NOT_FOUND);
+    }
+    
+}

--- a/docs/source/database/index.rst
+++ b/docs/source/database/index.rst
@@ -7,9 +7,9 @@ The schema can be created / populated using the SQL scripts in the source code d
 The database connection settings are taken from the geOrchestra default.properties configuration file, and mapped to
 internal configuration variables (e.g. ${pgsqlHost}).
 
-To configure the default.properties location and environment variable (georchestra-config) needs to be configured for
-the MapStore JVM:
+To configure the default.properties location the default georchestra environment variable is used (georchestra.datadir).
+For local development, this must be configured for the JVM:
 
  .. code-block:: console
 
-    -Dgeorchestra-config=file:/etc/georchestra/default.properties
+    -Dgeorchestra.datadir=/etc/georchestra

--- a/docs/source/developer/index.rst
+++ b/docs/source/developer/index.rst
@@ -1,0 +1,86 @@
+Developer Guide
+===============
+To start using the MapStore GeOrchestra project as a developer you need the following:
+ * install the needed requirements:
+   * NodeJS (>=8)
+   * JDK (>= 8)
+   * Maven (>= 3.x)
+
+ * clone the GitHub repository:
+
+ .. code-block:: console
+
+    git clone --recursive https://github.com/georchestra/mapstore2-georchestra
+
+ * from the cloned source, install the dependencies from the npm registry:
+
+ .. code-block:: console
+
+    npm install
+
+ * do a full build using the build script:
+
+ .. code-block:: console
+
+    ./build.sh
+
+
+Configuring the backend
+^^^^^^^^^^^^^^^^^^^^^^^
+
+To develop locally you will need to use a proxied backend. To configure your backend of choice you need to properly change the webpack.config.js file,
+in particular you need to change the following variables:
+ 
+ * DEV_PROTOCOL: http or https
+ * DEV_HOST: host and port of the backend
+
+ .. code-block:: javascript
+
+    const DEV_PROTOCOL = "http";
+    const DEV_HOST = "localhost:8080";
+
+
+You can either:
+ * use an online backend
+ * deploy and run your just build backend on a Tomcat instance
+
+To deploy your local backend you will need to:
+
+ * copy the mapstore.war from web/target to your Tomcat webapps folder
+ * create a local GeOrchestra datadir anywhere in your PC and copy the following inside it:
+  * a standard GeOrchestra default.properties file with generic configuration (database and LDAP settings for example)
+  * the datadir/mapstore folder from web/target/GeOrchestra with the mapstore specific configuration files
+ * add the georchestra.datadir environment variable to the Tomcat setenv script to point to your datadir folder
+
+ .. code-block:: console
+
+    -Dgeorchestra.datadir=/etc/georchestra
+
+ * properly change the configuration files, in particular to set the database and LDAP repository connection settings
+
+If you don't have a local database and LDAP repository properly configured for GeOrchestra you can use remote ones.
+Remember: to use a local backend both a PostgreSQL database and LDAP repository needs to be available and properly populated.
+
+Developing the frontend
+^^^^^^^^^^^^^^^^^^^^^^^
+
+To start the frontend locally, just run:
+
+ .. code-block:: console
+
+    npm start
+
+Your application will be available at http://localhost:8081
+
+Mocking security
+^^^^^^^^^^^^^^^^
+
+When working locally you won't have the security proxy authentication enabled, but you can simulate it using a specific
+Chrome extension called ModHeader.
+
+Install this extension and configure it to set the following request headers:
+
+ * sec-username: the username logged in
+ * sec-roles: a semicolon delimited list of roles (e.g. ROLE_MAPSTORE_ADMIN)
+
+Remember to disable the extension when you don't need it.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,4 +12,5 @@ Welcome to Georchestra documentation!
    mapstore/index
    security/index
    database/index
+   developer/index
    localize

--- a/docs/source/security/index.rst
+++ b/docs/source/security/index.rst
@@ -88,12 +88,12 @@ This ia also configured in the geostore-security-proxy.xml file:
 LDAP connection settings are taken from the geOrchestra default.properties configuration file, and mapped to
 internal configuration variables (e.g. ${ldapHost}).
 
-To configure the default.properties location and environment variable (georchestra-config) needs to be configured for
-the MapStore JVM:
+To configure the default.properties location the default georchestra environment variable is used (georchestra.datadir).
+For local development, this must be configured for the JVM:
 
  .. code-block:: console
 
-    -Dgeorchestra-config=file:/etc/georchestra/default.properties
+    -Dgeorchestra.datadir=/etc/georchestra
 
 Here a diagram of how the various pieces work together:
 

--- a/js/app.jsx
+++ b/js/app.jsx
@@ -27,7 +27,7 @@ ConfigUtils.setConfigProp('geoStoreUrl', 'rest/geostore/');
  *
  * ConfigUtils.setLocalConfigurationFile('localConfig.json');
  */
-ConfigUtils.setLocalConfigurationFile('localConfig.json');
+ConfigUtils.setLocalConfigurationFile('config');
 
 /**
  * Use a custom application configuration file with:

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
 
     <modules>
         <module>web</module>
+        <module>backend</module>
     </modules>
 
 </project>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -16,6 +16,12 @@
   </properties>
 
   <dependencies>
+    <!-- backend -->
+    <dependency>
+        <groupId>it.geosolutions.GeOrchestra</groupId>
+        <artifactId>GeOrchestra-backend</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </dependency>
     <!-- ================================================================ -->
     <!-- GeoStore modules -->
     <!-- ================================================================ -->
@@ -398,6 +404,50 @@
                                 <directory>${basedir}/../MapStore2/web/client</directory>
                                 <includes>
                                     <include>localConfig.json</include>
+                                </includes>
+                            </resource>
+                        </resources>
+                    </configuration>
+                </execution>
+                <execution>
+                    <id>georchestra datadir</id>
+                    <phase>process-classes</phase>
+                    <goals>
+                        <goal>copy-resources</goal>
+                    </goals>
+                    <configuration>
+                        <outputDirectory>${basedir}/target/GeOrchestra/datadir/mapstore</outputDirectory>
+                        <encoding>UTF-8</encoding>
+                        <resources>
+                            <resource>
+                                <directory>${basedir}/../MapStore2/web/client</directory>
+                                <includes>
+                                    <include>localConfig.json</include>
+                                </includes>
+                            </resource>
+                            <resource>
+                                <directory>${basedir}/src/main/resources</directory>
+                                <includes>
+                                    <include>*.properties</include>
+                                </includes>
+                            </resource>
+                        </resources>
+                    </configuration>
+                </execution>
+                <execution>
+                    <id>georchestra datadir printing</id>
+                    <phase>process-classes</phase>
+                    <goals>
+                        <goal>copy-resources</goal>
+                    </goals>
+                    <configuration>
+                        <outputDirectory>${basedir}/target/GeOrchestra/datadir/mapstore/printing</outputDirectory>
+                        <encoding>UTF-8</encoding>
+                        <resources>
+                            <resource>
+                                <directory>${basedir}/../MapStore2/resources/geoserver/print</directory>
+                                <includes>
+                                    <include>*</include>
                                 </includes>
                             </resource>
                         </resources>

--- a/web/src/main/resources/applicationContext.xml
+++ b/web/src/main/resources/applicationContext.xml
@@ -29,7 +29,7 @@
         <!-- Site specific initialization. Please specify a path in the ovr file-->
         <property name="userGroupListInitFile" value="classpath:sample_groups.xml" />
         <!-- The default password encoder -->
-        <property name="passwordEncoder" ref="${passwordEncoderUsed}"></property>	
+        <property name="passwordEncoder" ref="digestPasswordEncoder"></property>	
         
         
     </bean>
@@ -106,9 +106,9 @@
         <property name="order" value="0"/>
         <property name="locations">
             <list>
-                <value>classpath:geostore.properties</value>
                 <value>classpath*:geostore.properties</value>
-                <value>${georchestra-config}</value>
+                <value>file:${georchestra.datadir:}/default.properties</value>
+                <value>file:${georchestra.datadir:}/mapstore/geostore.properties</value>
             </list>
         </property>
         <property name="ignoreResourceNotFound" value="false"/>
@@ -136,7 +136,7 @@
                 <entry key="hibernate.connection.autocommit" value="true"/>
                 <entry key="hibernate.generate_statistics" value="false"/>
                 <entry key="hibernate.hbm2ddl.auto" value="validate" />
-                <entry key="hibernate.default_schema" value="geostore" />
+                <entry key="hibernate.default_schema" value="${pgsqlGeoStoreSchema:geostore}" />
             </map>
         </property>
     </bean>

--- a/web/src/main/resources/geostore-datasource-ovr.properties
+++ b/web/src/main/resources/geostore-datasource-ovr.properties
@@ -1,2 +1,0 @@
-geostoreDataSource.url=jdbc:h2:./webapps/GeOrchestra/geostore
-geostoreEntityManagerFactory.jpaPropertyMap[hibernate.hbm2ddl.auto]=update

--- a/web/src/main/resources/geostore.properties
+++ b/web/src/main/resources/geostore.properties
@@ -1,0 +1,63 @@
+### PostgreSQL properties
+
+# PostgreSQL server domain name
+# Domain name, or IP address, of the PostgreSQL server
+pgsqlHost=db
+
+# PostgreSQL server port
+# Listening port of the PostgreSQL server
+pgsqlPort=5432
+
+# PostgreSQL database name
+# Default common PostgreSQL database for all geOrchestra modules
+pgsqlDatabase=georchestra
+
+# User to connect to PostgreSQL server
+# Default common PostgreSQL user for all geOrchestra modules
+pgsqlUser=georchestra
+
+# Password to connect to PostgreSQL server
+# Default common password of PostgreSQL user for all geOrchestra modules
+pgsqlPassword=georchestra
+
+### LDAP properties
+
+# LDAP server domain name
+# Domain name, or IP address, of the LDAP server
+ldapHost=ldap
+
+# LDAP server port
+# Listening port of the LDAP server
+ldapPort=389
+
+# LDAP Scheme
+# ldap or ldaps
+ldapScheme=ldap
+
+# Base DN of the LDAP directory
+# Base Distinguished Name of the LDAP directory. Also named root or suffix, see
+# http://www.zytrax.com/books/ldap/apd/index.html#base
+ldapBaseDn=dc=georchestra,dc=org
+
+# Administrator DN
+# Distinguished name of the administrator user that connects to the LDAP server
+ldapAdminDn=cn=admin,dc=georchestra,dc=org
+
+# Administrator password
+# Password of the administrator user that connects to the LDAP server
+ldapAdminPassword=secret
+
+# Users RDN
+# Relative distinguished name of the "users" LDAP organization unit. E.g. if the
+# complete name (or DN) is ou=users,dc=georchestra,dc=org, the RDN is ou=users.
+ldapUsersRdn=ou=users
+
+# Roles RDN
+# Relative distinguished name of the "roles" LDAP organization unit. E.g. if the
+# complete name (or DN) is ou=roles,dc=georchestra,dc=org, the RDN is ou=roles.
+ldapRolesRdn=ou=roles
+
+# Organizations RDN
+# Relative distinguished name of the "orgs" LDAP organization unit. E.g. if the
+# complete name (or DN) is ou=orgs,dc=georchestra,dc=org, the RDN is ou=orgs.
+ldapOrgsRdn=ou=orgs

--- a/web/src/main/webapp/WEB-INF/web.xml
+++ b/web/src/main/webapp/WEB-INF/web.xml
@@ -18,13 +18,18 @@
 
     <context-param>
       <param-name>proxyPropPath</param-name>
-      <param-value>/proxy.properties</param-value>
+      <param-value>/proxy.properties,${georchestra.datadir}/mapstore/proxy.properties</param-value>
     </context-param>
 
     <!-- spring context loader -->
     <listener>
 		<listener-class>org.springframework.web.util.Log4jConfigListener</listener-class>
     </listener>
+
+	<context-param>
+		<param-name>log4jConfigLocation</param-name>
+		<param-value>file:${georchestra.datadir}/mapstore/log4j.properties</param-value>
+	</context-param>
 
 	<!--
       - Loads the root application context of this web app at startup.
@@ -63,6 +68,21 @@
 		<url-pattern>*.js</url-pattern>
 	</filter-mapping>
 
+	<!-- ConfigLoader Servlet -->
+	<servlet>
+		<servlet-name>ConfigLoader</servlet-name>
+		<servlet-class>it.geosolutions.georchestra.ConfigLoader</servlet-class>
+		<init-param>
+			<param-name>configLocation</param-name>
+			<param-value>${georchestra.datadir}/mapstore/localConfig.json,localConfig.json</param-value>
+		</init-param>
+	</servlet>
+
+	<servlet-mapping>
+		<servlet-name>ConfigLoader</servlet-name>
+		<url-pattern>/config/*</url-pattern>
+	</servlet-mapping>
+
     <!-- CXF Servlet -->
 	<servlet>
 		<servlet-name>CXFServlet</servlet-name>
@@ -91,7 +111,7 @@
        <servlet-class>org.mapfish.print.servlet.MapPrinterServlet</servlet-class>
        <init-param>
          <param-name>config</param-name>
-         <param-value>printing/config.yaml</param-value>
+         <param-value>${georchestra.datadir}/mapstore/printing/config.yaml</param-value>
        </init-param>
     </servlet>
     <servlet-mapping>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,68 +3,94 @@ const path = require("path");
 const themeEntries = require('./themes.js').themeEntries;
 const extractThemesPlugin = require('./themes.js').extractThemesPlugin;
 
+const DEV_PROTOCOL = "https";
 const DEV_HOST = "georchestra.geo-solutions.it";
 
-module.exports = require('./MapStore2/build/buildConfig')(
+module.exports = require("./MapStore2/build/buildConfig")(
     {
-        'GeOrchestra': path.join(__dirname, "js", "app"),
-        'GeOrchestra-embedded': path.join(__dirname, "MapStore2", "web", "client", "product", "embedded"),
-        'GeOrchestra-api': path.join(__dirname, "MapStore2", "web", "client", "product", "api")
+        GeOrchestra: path.join(__dirname, "js", "app"),
+        "GeOrchestra-embedded": path.join(
+            __dirname,
+            "MapStore2",
+            "web",
+            "client",
+            "product",
+            "embedded"
+        ),
+        "GeOrchestra-api": path.join(
+            __dirname,
+            "MapStore2",
+            "web",
+            "client",
+            "product",
+            "api"
+        )
     },
     themeEntries,
     {
         base: __dirname,
         dist: path.join(__dirname, "dist"),
         framework: path.join(__dirname, "MapStore2", "web", "client"),
-        code: [path.join(__dirname, "js"), path.join(__dirname, "MapStore2", "web", "client")]
+        code: [
+            path.join(__dirname, "js"),
+            path.join(__dirname, "MapStore2", "web", "client")
+        ]
     },
     extractThemesPlugin,
     false,
     "dist/",
-    '.GeOrchestra',
+    ".GeOrchestra",
     [],
     {
         "@mapstore": path.resolve(__dirname, "MapStore2", "web", "client"),
         "@js": path.resolve(__dirname, "js")
     },
     {
-        '/rest/geostore': {
-            target: `https://${DEV_HOST}/mapstore`,
+        "/rest/geostore": {
+            target: `${DEV_PROTOCOL}://${DEV_HOST}/mapstore`,
             secure: false,
             headers: {
                 host: `${DEV_HOST}`
             }
         },
-        '/pdf': {
-            target: `https://${DEV_HOST}/mapstore`,
+        "/config": {
+            target: `${DEV_PROTOCOL}://${DEV_HOST}/mapstore`,
             secure: false,
             headers: {
                 host: `${DEV_HOST}`
             }
         },
-        '/mapstore/pdf': {
-            target: `https://${DEV_HOST}`,
+        "/pdf": {
+            target: `${DEV_PROTOCOL}://${DEV_HOST}/mapstore`,
             secure: false,
             headers: {
                 host: `${DEV_HOST}`
             }
         },
-        '/proxy': { // proxy of GeOrchestra is already configured
-            target: `https://${DEV_HOST}/mapstore`,
+        "/mapstore/pdf": {
+            target: `${DEV_PROTOCOL}://${DEV_HOST}`,
             secure: false,
             headers: {
                 host: `${DEV_HOST}`
             }
         },
-        '/geonetwork': {
-            target: `https://${DEV_HOST}/geonetwork`,
+        "/proxy": {
+            // proxy of GeOrchestra is already configured
+            target: `${DEV_PROTOCOL}://${DEV_HOST}/mapstore`,
             secure: false,
             headers: {
                 host: `${DEV_HOST}`
             }
         },
-        '/header': {
-            target: `https://${DEV_HOST}`,
+        "/geonetwork": {
+            target: `${DEV_PROTOCOL}://${DEV_HOST}/geonetwork`,
+            secure: false,
+            headers: {
+                host: `${DEV_HOST}`
+            }
+        },
+        "/header": {
+            target: `${DEV_PROTOCOL}://${DEV_HOST}`,
             secure: false,
             headers: {
                 host: `${DEV_HOST}`


### PR DESCRIPTION
This is the list of externalized configuration (to be put in <georchestra.datadir>/mapstore):

 * localConfig.json
 * proxy.properties
 * log4j.properties
 * geostore.properties
 * printing folder (config.yaml + resources)

A lot of configuration properties are also loaded from <georchestra.datadir>/default.properties