### PR TITLE
Fix context creator layout

### DIFF
--- a/js/pages/ContextCreator.jsx
+++ b/js/pages/ContextCreator.jsx
@@ -1,13 +1,16 @@
-import React, {useEffect} from "react";
+import React /* {useEffect} */ from "react";
 import Page from '@mapstore/product/pages/ContextCreator';
-import ConfigUtils from "@mapstore/utils/ConfigUtils";
+// import ConfigUtils from "@mapstore/utils/ConfigUtils";
 
 export default (props) => {
+    /* This scauses a wrong effect with the size of the TOC, Catalog and other side panels
+    // TODO: fix issues with layout and restore FeatureGrid, and remove css fixes from georchestra.less
     useEffect(() => {
         ConfigUtils.setConfigProp('mapLayout', { left: { sm: 300, md: 500, lg: 600 }, right: { md: 658 }, bottom: { sm: 130 } });
         return () => {
             ConfigUtils.setConfigProp('mapLayout', { left: { sm: 300, md: 500, lg: 600 }, right: { md: 658 }, bottom: { sm: 30 } });
         };
     }, []);
+    */
     return <Page {...props}/>;
 };

--- a/localConfig.json
+++ b/localConfig.json
@@ -585,34 +585,7 @@
           {
             "name": "ContextCreator",
             "cfg": {
-              "saveDestLocation": "/admin",
-              "viewerPlugins": [
-                "Map",
-                "BackgroundSelector",
-                "MetadataExplorer",
-                "TOC",
-                "TOCItemsSettings",
-                "DrawerMenu",
-                "OmniBar",
-                "BurgerMenu",
-                "AddGroup",
-                "Notifications",
-                "QueryPanel",
-                "FeatureEditor",
-                "MapFooter",
-                "CRSSelector",
-                "MousePosition",
-                "ScaleBox",
-                "Toolbar",
-                "MapLoading",
-                "Identify",
-                "Locate",
-                "ZoomIn",
-                "ZoomOut",
-                "ZoomAll",
-                "Annotations",
-                "MapImport"
-              ]
+              "saveDestLocation": "/admin"
             }
           },
           "Notifications",

--- a/themes/default/georchestra.less
+++ b/themes/default/georchestra.less
@@ -6,7 +6,15 @@
         display: inline-block;
     }
 }
+/* FIXES FOR CONTEXT CREATOR LAYOUT TOOLBAR AND BACKGROUND */
+#page-context-creator .mapToolbar {
+    bottom: 120px !important;
+}
 
+#page-context-creator .background-plugin-position {
+    bottom: 120px !important;
+}
+/* END OF FIXES FOR CONTEXT CREATOR LAYOUT TOOLBAR AND BACKGROUND */
 #georchestra-notallowed {
     position: absolute;
     width: 100%;


### PR DESCRIPTION
Restored original CSS solution for Toolbar and Background selector
removed feature grid from viewerPlugins
removed configurations that are uinuseful (equal to defaults)