### PR TITLE
Use github actions for CI

### DIFF
--- a/.github/workflows/mapstore.yml
+++ b/.github/workflows/mapstore.yml
@@ -8,6 +8,9 @@ jobs:
     - name: "checking out"
       uses: actions/checkout@v2
 
+    - name: "Checking out submodules"
+      uses: textbook/git-checkout-submodule-action@2.0.0
+
     - name: "setting up Java"
       uses: actions/setup-java@v1
       with:
@@ -24,7 +27,7 @@ jobs:
         cache-name: cache-node-modules
       with:
         path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package.json') }}
         restore-keys: |
           ${{ runner.os }}-build-${{ env.cache-name }}-
           ${{ runner.os }}-build-

--- a/.github/workflows/mapstore.yml
+++ b/.github/workflows/mapstore.yml
@@ -6,10 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "checking out"
-      uses: actions/checkout@v2
-
-    - name: "Checking out submodules"
-      uses: textbook/git-checkout-submodule-action@2.0.0
+      uses: actions/checkout@master
+      with:
+        submodules: true
 
     - name: "setting up Java"
       uses: actions/setup-java@v1

--- a/.github/workflows/mapstore.yml
+++ b/.github/workflows/mapstore.yml
@@ -53,13 +53,13 @@ jobs:
       run: npm run lint
 
     - name: "package with Maven"
-      run: mvn -B clean install -Dmapstore2.version=$GITHUB_SHA
+      run: mvn -B clean install -Dmapstore2.version=${{ github.sha }}
 
     - name: "copy resulting war"
-      run: mkdir -p scratch && cp web/target/GeOrchestra.war scratch/mapstore-$(GITHUB_SHA).war
+      run: mkdir -p scratch && cp web/target/GeOrchestra.war scratch/mapstore-${{ github.sha }}.war
 
     - name: "publish war as artifact"
       uses: actions/upload-artifact@v1
       with:
         name: mapstore.war
-        path: scratch/mapstore-$(GITHUB_SHA).war
+        path: scratch/mapstore-${{ github.sha }}.war

--- a/.github/workflows/mapstore.yml
+++ b/.github/workflows/mapstore.yml
@@ -1,0 +1,43 @@
+name: "mapstore"
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: "checking out"
+      uses: actions/checkout@v2
+
+    - name: "setting up Java"
+      uses: actions/setup-java@v1
+      with:
+        java-version: '8.x'
+
+    - name: "setting up npm"
+      uses: actions/setup-node@v1
+      with:
+        node-version: '10.x'
+
+    - name: "cache node modules"
+      uses: actions/cache@v1
+      env:
+        cache-name: cache-node-modules
+      with:
+        path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
+    - name: "install dependencies"
+      run: npm install
+
+    - name: "build"
+      run: npm run compile
+
+    - name: "run lint"
+      run: npm run lint
+
+    - name: "package with Maven"
+      run: mvn -B clean install -Dmapstore2.version=$GITHUB_SHA

--- a/.github/workflows/mapstore.yml
+++ b/.github/workflows/mapstore.yml
@@ -6,9 +6,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "checking out"
-      uses: actions/checkout@master
-      with:
-        submodules: true
+      uses: actions/checkout@v2
+    - name: Checkout submodules
+      run: |
+        auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+        git submodule sync --recursive
+        git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
 
     - name: "setting up Java"
       uses: actions/setup-java@v1

--- a/.github/workflows/mapstore.yml
+++ b/.github/workflows/mapstore.yml
@@ -32,6 +32,14 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
 
+    - name: "Maven repository caching"
+      uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: mapstore-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          mapstore-${{ runner.os }}-maven-
+
     - name: "install dependencies"
       run: npm install
 

--- a/.github/workflows/mapstore.yml
+++ b/.github/workflows/mapstore.yml
@@ -54,3 +54,12 @@ jobs:
 
     - name: "package with Maven"
       run: mvn -B clean install -Dmapstore2.version=$GITHUB_SHA
+
+    - name: "copy resulting war"
+      run: mkdir -p scratch && cp web/target/GeOrchestra.war scratch/mapstore-$(GITHUB_SHA).war
+
+    - name: "publish war as artifact"
+      uses: actions/upload-artifact@v1
+      with:
+        name: mapstore.war
+        path: scratch/mapstore-$(GITHUB_SHA).war


### PR DESCRIPTION
Dunno what @geosolutions-it uses for CI, but @georchestra uses github actions since a month or so (see georchestra/georchestra#2931) - i've been tinkering with github actions on mapstore2-georchestra repo this morning, and finally got to a point where i have it building a war and making it available as an artifact, which allows to download a zip containing mapstore-$SHA.war.

I personally have zero interest in adding the goo for docker images/repo etc, but so far this fits my need (not having to pull/fetch/recompile locally).

@fvanderbiest what do you think about it ? @tdipisa do you have some plans wrt CI ?