### PR TITLE
Enables using extensions from the datadir

### DIFF
--- a/js/app.jsx
+++ b/js/app.jsx
@@ -31,10 +31,9 @@ ConfigUtils.setConfigProp("geoStoreUrl", "rest/geostore/");
  * ConfigUtils.setLocalConfigurationFile('localConfig.json');
  */
 ConfigUtils.setLocalConfigurationFile("rest/config/load/localConfig.json");
-/* ConfigUtils.setConfigProp(
-    "extensionsRegistry",
-    "rest/config/load/extensions.json"
-);*/
+ConfigUtils.setConfigProp("extensionsRegistry", "rest/config/load/extensions.json");
+ConfigUtils.setConfigProp("contextPluginsConfiguration", "rest/config/load/pluginsConfig.json");
+ConfigUtils.setConfigProp("extensionsFolder", "rest/config/loadasset?resource=");
 
 /**
  * Use a custom application configuration file with:


### PR DESCRIPTION
With this change everything related to extensions is loaded from the datadir instead of the mapstore folder, in particular:
 * extensions.json
 * pluginsConfig.json
 * all the bundles and assets used by the extensions (js, translations)

Note that the plugin uploader already stores stuff in the datadir, this only enables loading them from there.