### PR TITLE
Updated MapStore to latest to include some fixes

### DIFF
--- a/docs/source/configuration/index.rst
+++ b/docs/source/configuration/index.rst
@@ -19,15 +19,18 @@ More in detail:
    * proxy.properties: MapStore proxy configuration (see here: https://github.com/geosolutions-it/http-proxy/wiki/Configuring-Http-Proxy)   for further details)
    * log4j.properties: logging configuration (see here: https://logging.apache.org/log4j/2.x/manual/configuration.html#ConfigurationSyntax>)
    * localConfig.json: main frontend configuration file, in JSON format (see here: https://mapstore.readthedocs.io/en/latest/developer-guide/local-config/)
+   * config.json: map configuration file for initial viewer map
+   * new.json: map configuration file for new maps
+   * printing: folder with mapfish-print configuration files, config.yaml and related resource (see here: https://github.com/geosolutions-it/mapfish-print/wiki>)
    * extensions.json: dynamic registry of currently installed extensions, in JSON format
    * pluginsConfig.json: dynamic registry of available plugins (both standard and extensions) for the context configurator, in JSON format
-   * printing: folder with mapfish-print configuration files, config.yaml and related resource (see here: https://github.com/geosolutions-it/mapfish-print/wiki>)
    * dist subfolder: will contain all the dynamically uploaded extensions, one folder for each of them, with all the extension assets (javascript bundle, translations, etc.)
 
 If the datadir is not configured / used in a particular environment, default configurations will be applied.
 
 If the datadir is configured, but some of the above mentioned files are missing from it, a default fallback will
-be used.
+be used. The fallback will look for files in the web application root folder (webapps/mapstore), so the configurations
+from the original mapstore war file will be used.
 
 This allows the administrator to find a good compromise between two conflicting needs:
  * customizing your geOrchestra MapStore installation
@@ -35,20 +38,22 @@ This allows the administrator to find a good compromise between two conflicting 
 
 It is important to understand that if a configuration file is loaded from the datadir, it will not be
 upgraded when a new version of the application is installed, and any necessary upgrades should be done manually.
-So, our advice is: put a configuration file in the datadir only if it is dynamically changed from the application or
-you need to customize it.
+So, our advice is: put a configuration file in the datadir only if you need to customize it.
+A particular attention is needed for localConfig.json: this is where the available MapStore plugins are registered, so,
+if you copied it in the datadir, you will need to manually add new plugins when you upgrade to a new version.
 
-Dynamic files are for example:
+It is also possible to store dynamic files (files written by the MapStore UI) outside of the datadir, in a
+dedicated location.
+
+Dynamic files are:
  * extensions.json
  * pluginsConfig.json
  * the dist subfolder
 
-These files are updated by the extensions upload functionality, so they have to be put in the datadir, or they will be
-removed at every application update.
+These files are updated by the extensions upload functionality.
 
-All the other files should be put in the datadir only if you need to customize them.
-A particular attention is needed for localConfig.json: this is where the available MapStore plugins are registered, so,
-if you copied it in the datadir, you will need to manually add new plugins when you upgrade to a new version.
+To set a different folder for these files, you have to set the georchestra.extensions JVM option to the desired path.
+If not set, also dynamic files will be stored in the standard datadir.
 
 More details about configuration aspects can be found in the following sections:
 

--- a/js/app.jsx
+++ b/js/app.jsx
@@ -36,6 +36,7 @@ ConfigUtils.setLocalConfigurationFile("rest/config/load/localConfig.json");
 ConfigUtils.setConfigProp("extensionsRegistry", "rest/config/load/extensions.json");
 ConfigUtils.setConfigProp("contextPluginsConfiguration", "rest/config/load/pluginsConfig.json");
 ConfigUtils.setConfigProp("extensionsFolder", "rest/config/loadasset?resource=");
+ConfigUtils.setConfigProp("configurationFolder", "rest/config/load/");
 
 Providers.georchestra = serverbackup;
 

--- a/localConfig.json
+++ b/localConfig.json
@@ -474,7 +474,15 @@
                     "showAddAsAnnotation": true
                   }
                 }
-            }, "Print", "MapImport", "MapExport", {
+            }, {
+              "name": "Print",
+              "cfg": {
+                "useFixedScales": true,
+                "mapPreviewOptions": {
+                  "enableScalebox": true
+                }
+              }
+            }, "MapImport", "MapExport", {
                 "name": "Settings",
                 "cfg": {
                     "wrap": true

--- a/web/src/main/resources/mapstore.properties
+++ b/web/src/main/resources/mapstore.properties
@@ -16,6 +16,6 @@
 # ldapUsersRdn=
 # ldapRolesRdn=
 
-datadir.location=${georchestra.datadir}/mapstore
+datadir.location=${georchestra.extensions:},${georchestra.datadir}/mapstore
 overrides.config=../default.properties
 overrides.mappings=header.url=headerUrl,header.height=headerHeight


### PR DESCRIPTION
 * #221 new.json and config.json can be put in datadir now
 * #221 uploaded extensions can be stored outside of the datadir
 * #54 enabled printing at fixed scales
 * extensions upload UI error if file is not zip

**Note 1**: printing at fixed scales is done by properly configuring the Print plugin in localConfig.json.
It will not work for existing contexts, where the print plugin does not have these settings.

**Note 2**: to enable the uploaded extensions folder, a new JVM option need to be set, the option is called georchestra.extensions (e.g. -Dgeorchestra.extensions=/tmp/mapstore); if not set uploaded extensions will be put in the usual datadir 