### PR TITLE
Fixed role groups mapping

### DIFF
--- a/docs/source/security/index.rst
+++ b/docs/source/security/index.rst
@@ -28,7 +28,7 @@ The filter is configured in the geostore-security-proxy.xml file:
     <bean id="georchestraAuthenticationProvider"
 		class="it.geosolutions.geostore.services.rest.security.PreAuthenticatedAuthenticationProvider">
 	</bean>
-    
+
     <!-- GeOrchestra header based Auth Filter -->
     <bean class="it.geosolutions.geostore.services.rest.security.HeadersAuthenticationFilter"
         id="headersProcessingFilter">
@@ -43,7 +43,7 @@ The filter is configured in the geostore-security-proxy.xml file:
         <constructor-arg>
             <map>
                 <!-- add more entries to map other roles to MapStore ADMIN -->
-                <entry key="ROLE_MAPSTORE_ADMIN" value="ADMIN"/>
+                <entry key="MAPSTORE_ADMIN" value="ADMIN"/>
             </map>
         </constructor-arg>
     </bean>
@@ -56,7 +56,7 @@ and use it in the Admin UI, to assign permissions to MapStore resources and func
 This ia also configured in the geostore-security-proxy.xml file:
 
  .. code-block:: xml
-    
+
     <!-- GeOrchestra LDAP DAOs -->
     <bean id="ldap-context" class="org.springframework.security.ldap.DefaultSpringSecurityContextSource">
 		<constructor-arg value="${ldapScheme}://${ldapHost}:${ldapPort}/${ldapBaseDn}" />

--- a/web/src/main/resources/geostore-spring-security.xml
+++ b/web/src/main/resources/geostore-spring-security.xml
@@ -69,7 +69,7 @@
     <bean id="rolesMapper" class="it.geosolutions.geostore.core.security.SimpleGrantedAuthoritiesMapper">
         <constructor-arg>
             <map>
-                <entry key="ROLE_MAPSTORE_ADMIN" value="ADMIN"/>
+                <entry key="MAPSTORE_ADMIN" value="ADMIN"/>
             </map>
         </constructor-arg>
     </bean>

--- a/web/src/main/resources/geostore-spring-security.xml
+++ b/web/src/main/resources/geostore-spring-security.xml
@@ -58,6 +58,7 @@
             <property name="groupsHeader" value="sec-roles"/>
             <property name="listDelimiter" value=";"/>
             <property name="authoritiesMapper" ref="rolesMapper"/>
+            <property name="groupHeaderPrefix" value="ROLE_"/>
 	</bean>
 
     <!-- GeOrchestra groups to roles mapper for Headers Auth Filter -->

--- a/web/src/main/resources/geostore-spring-security.xml
+++ b/web/src/main/resources/geostore-spring-security.xml
@@ -58,7 +58,11 @@
             <property name="groupsHeader" value="sec-roles"/>
             <property name="listDelimiter" value=";"/>
             <property name="authoritiesMapper" ref="rolesMapper"/>
-            <property name="groupHeaderPrefix" value="ROLE_"/>
+            <property name="groupMapper">
+            	<bean class="it.geosolutions.geostore.services.rest.utils.SpelMapper">
+            		<constructor-arg value="name.replace('ROLE_', '')" />
+            	</bean>
+            </property>
 	</bean>
 
     <!-- GeOrchestra groups to roles mapper for Headers Auth Filter -->


### PR DESCRIPTION
This PR (needs an update of GeoStore/Mapstore as from this https://github.com/geosolutions-it/geostore/pull/207) allow to map headers role removing the `ROLE_` prefix, so groups match with prefixes