### PR TITLE
Update localConfig.json

### DIFF
--- a/localConfig.json
+++ b/localConfig.json
@@ -42,7 +42,8 @@
       {"name": "router", "path": "router.location.pathname"},
       {"name": "browser", "path": "browser"},
       {"name": "geostorymode", "path": "geostory.mode"},
-      {"name": "featuregridmode", "path": "featuregrid.mode"}],
+      {"name": "featuregridmode", "path": "featuregrid.mode"},
+      {"name": "printEnabled","path": "print.capabilities"}],
     "projectionDefs": [{
       "code": "EPSG:2154",
       "def": "+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs",


### PR DESCRIPTION
This PR ports the configuration update required by print plugin to auto-enable/disable when the back-end is not present in localConfig.json of georchestra.

See this: 
https://github.com/geosolutions-it/MapStore2/pull/5375/files#diff-fe17a06a91c4d9d944823fcddda68476R53