### PR TITLE
#264: updated mapstore reference and default configuration

### DIFF
--- a/localConfig.json
+++ b/localConfig.json
@@ -581,7 +581,10 @@
             "Timeline",
             "Playback",
             "FeedbackMask",
-            "StyleEditor"
+            "StyleEditor",
+            "Save",
+            "SaveAs",
+            "MapCatalog"
         ],
         "common": [],
         "maps": [


### PR DESCRIPTION
Add MapCatalog, Save and SaveAs plugin to default localConfig.json.