### PR TITLE
Fix logging for consistency with other georchestra modules

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -92,6 +92,17 @@
       <version>1.7</version>
     </dependency>
     <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>1.2.17</version>
+    </dependency>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>apache-log4j-extras</artifactId>
+      <version>1.1</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>com.lowagie</groupId>
       <artifactId>itext</artifactId>
       <version>2.1.5</version>

--- a/web/src/main/resources/log4j.properties
+++ b/web/src/main/resources/log4j.properties
@@ -9,7 +9,10 @@ log4j.logger.org.hibernate=INFO
 log4j.logger.com.trg=INFO
 
 # File appender
-log4j.appender.fileAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.fileAppender=org.apache.log4j.rolling.RollingFileAppender
+log4j.appender.fileAppender.rollingPolicy=org.apache.log4j.rolling.TimeBasedRollingPolicy
+log4j.appender.fileAppender.rollingPolicy.FileNamePattern=/tmp/mapstore.%d.log.gz
 log4j.appender.fileAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.fileAppender.Append = true
 log4j.appender.fileAppender.layout.ConversionPattern=%p   %d{yyyy-MM-dd HH:mm:ss.SSS}   %C{1}.%M() - %m %n
-log4j.appender.fileAppender.File=${catalina.base}/logs/GeOrchestra.log
+log4j.appender.fileAppender.File=/tmp/mapstore.log


### PR DESCRIPTION
logging in georchestra was uniformized in georchestra/georchestra#1268, would be nice to have a similar config by default for mapstore. needs to be included in georchestra/datadir#186 too.