### PR TITLE
Despite of original war name, make it mapstore.war

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN if [ "$TOMCAT_EXTRAS" = false ]; then \
     fi
 
 # Add war files to be deployed
-COPY docker/*.war "${CATALINA_BASE}/webapps/"
+COPY docker/*.war "${CATALINA_BASE}/webapps/mapstore.war"
 
 # Geostore externalization template. Disabled by default
 # COPY docker/geostore-datasource-ovr.properties "${CATALINA_BASE}/conf/"


### PR DESCRIPTION
to be sure that URI /mapstore is always the same

fixes #282 