### PR TITLE
#2 Remove all capital g from geOrchestra strings

### DIFF
--- a/.github/workflows/mapstore.yml
+++ b/.github/workflows/mapstore.yml
@@ -56,7 +56,7 @@ jobs:
       run: mvn -B clean install -Dmapstore2.version=${{ github.sha }}
 
     - name: "copy resulting war"
-      run: mkdir -p scratch && cp web/target/GeOrchestra.war scratch/mapstore-${{ github.sha }}.war
+      run: mkdir -p scratch && cp web/target/mapstore.war scratch/mapstore-${{ github.sha }}.war
 
     - name: "publish war as artifact"
       uses: actions/upload-artifact@v1
@@ -75,7 +75,7 @@ jobs:
         cp scratch/mapstore-${{ github.sha }}.war docker/MapStore-${{ steps.version.outputs.VERSION }}.war
         docker build . -t georchestra/mapstore:${{ steps.version.outputs.VERSION }}
         # mvn -B package dockerfile:build -Pdocker,log4j-logstash,sentry-log4j -DdockerImageName=georchestra/mapstore:${{ steps.version.outputs.VERSION }} -settings settings.xml
-      working-directory: ${{ github.workspace }} 
+      working-directory: ${{ github.workspace }}
     - name: "Logging in docker.io"
       if: github.repository == 'georchestra/mapstore2-georchestra'
       uses: azure/docker-login@v1
@@ -88,4 +88,4 @@ jobs:
       run: |
         docker tag georchestra/mapstore:${{ steps.version.outputs.VERSION }} georchestra/mapstore:latest
         docker push georchestra/mapstore:latest
-      working-directory: ${{ github.workspace }} 
+      working-directory: ${{ github.workspace }}

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@ geOrchestra
 ==========
 
 MapStore Project for geOrchestra
-------------
+--------------------------------
+
 Documentation: https://docs.georchestra.geo-solutions.it/ (domain will change)
 
 See https://georchestra.geo-solutions.it/ (work in progress)
 
-
 Building the project
-------------
+--------------------
 
 Clone the repository:
 
@@ -19,9 +19,9 @@ Install NodeJS, if needed, from [here](https://nodejs.org/dist/latest-v10.x/).( 
 
 Install Java SDK, if needed. Java 1.8, 9 and 11 are supported. You can download them from:
 
- * [1.8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
- * [9](https://www.oracle.com/technetwork/java/javase/downloads/java-archive-javase9-3934878.html)
- * [11](https://www.oracle.com/technetwork/java/javase/downloads/java-archive-javase11-5116896.html)
+* [1.8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
+* [9](https://www.oracle.com/technetwork/java/javase/downloads/java-archive-javase9-3934878.html)
+* [11](https://www.oracle.com/technetwork/java/javase/downloads/java-archive-javase11-5116896.html)
 
 Install latest Maven, if needed, from [here](https://maven.apache.org/download.cgi) (version 3.5.2 is required).
 
@@ -31,14 +31,14 @@ Build the deployable war:
 
 Where version_identifier is an optional identifier of the generated war that will be shown in the settings panel of the application.
 
-Deploy the generated GeOrchestra.war file (in web/target) to your favourite J2EE container (e.g. Tomcat).
+Deploy the generated `mapstore.war` file (in web/target) to your favorite J2EE container (e.g. Tomcat).
 
 Tomcat versions 7.x, 8.x and 9.x are supported.
 The latest of each can be donwloaded from:
 
- * [7.x](https://tomcat.apache.org/download-70.cgi)
- * [8.x](https://tomcat.apache.org/download-80.cgi)
- * [9.x](https://tomcat.apache.org/download-90.cgi)
+* [7.x](https://tomcat.apache.org/download-70.cgi)
+* [8.x](https://tomcat.apache.org/download-80.cgi)
+* [9.x](https://tomcat.apache.org/download-90.cgi)
 
 Building the documentation
 --------------------------

--- a/api.html
+++ b/api.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8">
         <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>GeOrchestra</title>
+        <title>geOrchestra</title>
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Raleway" type='text/css'>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.css" />
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.css" />
@@ -29,7 +29,7 @@
     </head>
     <body onload="init()">
         <div id="container" class="ms2"></div>
-        <script id="ms2-api" src="dist/GeOrchestra-api.js"></script>
+        <script id="ms2-api" src="dist/geOrchestra-api.js"></script>
         <script type="text/javascript">
         function init() {
             MapStore2.create('container', {

--- a/apiTemplate.html
+++ b/apiTemplate.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8">
         <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>GeOrchestra</title>
+        <title>geOrchestra</title>
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Raleway" type='text/css'>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.css" />
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.css" />

--- a/docs/source/developer/integration/index.rst
+++ b/docs/source/developer/integration/index.rst
@@ -35,12 +35,12 @@ The filter is configured in the geostore-security-proxy.xml file:
 		...
 	</security:http>
 
-    <!-- GeOrchestra header based Auth Provider -->
+    <!-- geOrchestra header based Auth Provider -->
     <bean id="georchestraAuthenticationProvider"
 		class="it.geosolutions.geostore.services.rest.security.PreAuthenticatedAuthenticationProvider">
 	</bean>
 
-    <!-- GeOrchestra header based Auth Filter -->
+    <!-- geOrchestra header based Auth Filter -->
     <bean class="it.geosolutions.geostore.services.rest.security.HeadersAuthenticationFilter"
         id="headersProcessingFilter">
             <property name="addEveryOneGroup" value="true"/>
@@ -68,7 +68,7 @@ This ia also configured in the geostore-security-proxy.xml file:
 
  .. code-block:: xml
 
-    <!-- GeOrchestra LDAP DAOs -->
+    <!-- geOrchestra LDAP DAOs -->
     <bean id="ldap-context" class="org.springframework.security.ldap.DefaultSpringSecurityContextSource">
 		<constructor-arg value="${ldapScheme}://${ldapHost}:${ldapPort}/${ldapBaseDn}" />
         <property name="userDn" value="${ldapAdminDn}"/>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,7 +6,7 @@
 Welcome to geOrchestra documentation!
 =====================================
 
-This documentation provides an overview of how use and configure MapStore inside GeOrchestra.
+This documentation provides an overview of how use and configure MapStore inside geOrchestra.
 
 .. toctree::
    :maxdepth: 4

--- a/embedded.html
+++ b/embedded.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8">
         <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>geOrchestra</title>
+        <title>geOrchestra Viewer</title>
         <style>
             body {
                 margin: 0;

--- a/embedded.html
+++ b/embedded.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8">
         <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>GeOrchestra</title>
+        <title>geOrchestra</title>
         <style>
             body {
                 margin: 0;
@@ -96,6 +96,6 @@
             <div class="_ms2_init_spinner _ms2_init_center"><div></div></div>
             <div class="_ms2_init_text _ms2_init_center">Loading MapStore</div>
         </div>
-        <script src="dist/GeOrchestra-embedded.js"></script>
+        <script src="dist/geOrchestra-embedded.js"></script>
     </body>
 </html>

--- a/embedded.html
+++ b/embedded.html
@@ -94,7 +94,7 @@
     <body>
         <div id="container">
             <div class="_ms2_init_spinner _ms2_init_center"><div></div></div>
-            <div class="_ms2_init_text _ms2_init_center">Loading MapStore</div>
+            <div class="_ms2_init_text _ms2_init_center">Loading</div>
         </div>
         <script src="dist/geOrchestra-embedded.js"></script>
     </body>

--- a/embeddedTemplate.html
+++ b/embeddedTemplate.html
@@ -94,7 +94,7 @@
     <body>
         <div id="container">
             <div class="_ms2_init_spinner _ms2_init_center"><div></div></div>
-            <div class="_ms2_init_text _ms2_init_center">Loading MapStore</div>
+            <div class="_ms2_init_text _ms2_init_center">Loading</div>
         </div>
     </body>
 </html>

--- a/embeddedTemplate.html
+++ b/embeddedTemplate.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8">
         <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>geOrchestra</title>
+        <title>geOrchestra Viewer</title>
         <style>
             body {
                 margin: 0;

--- a/embeddedTemplate.html
+++ b/embeddedTemplate.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8">
         <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>GeOrchestra</title>
+        <title>geOrchestra</title>
         <style>
             body {
                 margin: 0;

--- a/header.html
+++ b/header.html
@@ -5,11 +5,11 @@
     <meta charset="UTF-8">
     <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no">
-    <title>GeOrchestra Header</title>
+    <title>geOrchestra Header</title>
 </head>
 
 <body>
-    <h3 style="display: none">GeOrchestra Header</h3>
+    <h3 style="display: none">geOrchestra Header</h3>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
             align-items: center;
         }
         ._ms2_init_center::before {
-            content: 'Loading geOrchestra';
+            content: 'Loading';
             position: absolute;
             left: 50%;
             height: 1.5em;
@@ -135,7 +135,7 @@
         <iframe id="georchestra-header" src="header.html" scrolling="no" frameBorder="0"></iframe>
         <div id="container">
             <div class="_ms2_init_spinner _ms2_init_center"><div></div></div>
-            <div class="_ms2_init_text _ms2_init_center">Loading geOrchestra</div>
+            <div class="_ms2_init_text _ms2_init_center">Loading</div>
         </div>
         <script src="dist/geOrchestra.js"></script>
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8">
         <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no">
-        <title>geOrchestra</title>
+        <title>geOrchestra Viewer</title>
         <style>
         body {
             margin: 0;

--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
             <div class="_ms2_init_spinner _ms2_init_center"><div></div></div>
             <div class="_ms2_init_text _ms2_init_center">Loading geOrchestra</div>
         </div>
-        <script src="dist/GeOrchestra.js"></script>
+        <script src="dist/geOrchestra.js"></script>
 
     </body>
 </html>

--- a/indexTemplate.html
+++ b/indexTemplate.html
@@ -4,7 +4,7 @@
       <meta charset="UTF-8">
       <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
       <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no">
-      <title>geOrchestra</title>
+      <title>geOrchestra Viewer</title>
       <style>
       body {
         margin: 0;

--- a/indexTemplate.html
+++ b/indexTemplate.html
@@ -4,7 +4,7 @@
       <meta charset="UTF-8">
       <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
       <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no">
-      <title>GeOrchestra</title>
+      <title>geOrchestra</title>
       <style>
       body {
         margin: 0;

--- a/indexTemplate.html
+++ b/indexTemplate.html
@@ -21,7 +21,7 @@
         align-items: center;
       }
       ._ms2_init_center::before {
-          content: 'Loading geOrchestra';
+          content: 'Loading';
           position: absolute;
           left: 50%;
           height: 1.5em;
@@ -133,7 +133,7 @@
       <iframe id="georchestra-header" src="header.html" scrolling="no" frameBorder="0"></iframe>
       <div id="container">
           <div class="_ms2_init_spinner _ms2_init_center"><div></div></div>
-          <div class="_ms2_init_text _ms2_init_center">Loading geOrchestra</div>
+          <div class="_ms2_init_text _ms2_init_center">Loading</div>
       </div>
   </body>
 </html>

--- a/js/app.jsx
+++ b/js/app.jsx
@@ -25,7 +25,7 @@ ConfigUtils.setConfigProp("translationsPath", [
     "./MapStore2/web/client/translations",
     "./translations"
 ]);
-ConfigUtils.setConfigProp("themePrefix", "GeOrchestra");
+ConfigUtils.setConfigProp("themePrefix", "geOrchestra");
 ConfigUtils.setConfigProp("geoStoreUrl", "rest/geostore/");
 /**
  * Use a custom plugins configuration file with:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "GeOrchestra",
+    "name": "georchestra",
     "version": "1.0.0",
-    "description": "GeOrchestra",
+    "description": "geOrchestra",
     "repository": "https://github.com/georchestra/mapstore2-georchestra",
     "main": "index.js",
     "devDependencies": {

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>it.geosolutions.GeOrchestra</groupId>
-    <artifactId>GeOrchestra-root</artifactId>
+    <groupId>it.geosolutions.geOrchestra</groupId>
+    <artifactId>geOrchestra-root</artifactId>
     <packaging>pom</packaging>
     <version>1.0-SNAPSHOT</version>
-    <name>GeOrchestra - Root Project</name>
+    <name>geOrchestra - Root Project</name>
     <url>https://github.com/geosolutions-it/MapStore2-C169</url>
 
     <properties>

--- a/prod-webpack.config.js
+++ b/prod-webpack.config.js
@@ -13,18 +13,18 @@ const paths = {
 
 module.exports = require('./MapStore2/build/buildConfig')(
     {
-        'GeOrchestra': path.join(__dirname, "js", "app")
+        'geOrchestra': path.join(__dirname, "js", "app")
     },
     themeEntries,
     paths,
     extractThemesPlugin,
     true,
     "dist/",
-    '.GeOrchestra',
+    '.geOrchestra',
     [
         new HtmlWebpackPlugin({
             template: path.join(__dirname, 'indexTemplate.html'),
-            chunks: ['GeOrchestra'],
+            chunks: ['geOrchestra'],
             inject: true,
             hash: true
         })

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-GeOrchestra-1.0.0
+geOrchestra-1.0.0

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -2,13 +2,13 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>it.geosolutions.GeOrchestra</groupId>
-    <artifactId>GeOrchestra-root</artifactId>
+    <groupId>it.geosolutions.geOrchestra</groupId>
+    <artifactId>geOrchestra-root</artifactId>
     <version>1.0-SNAPSHOT</version>
   </parent>
-  <artifactId>GeOrchestra-web</artifactId>
+  <artifactId>geOrchestra-web</artifactId>
   <packaging>war</packaging>
-  <name>GeOrchestra - WAR</name>
+  <name>geOrchestra - WAR</name>
   <url>https://github.com/geosolutions-it/MapStore2-C169</url>
 
   <properties>
@@ -146,7 +146,7 @@
   </dependencies>
 
   <build>
-    <finalName>GeOrchestra</finalName>
+    <finalName>mapstore</finalName>
     <plugins>
         <plugin>
             <artifactId>maven-resources-plugin</artifactId>
@@ -159,7 +159,7 @@
                         <goal>copy-resources</goal>
                     </goals>
                     <configuration>
-                        <outputDirectory>${basedir}/target/GeOrchestra</outputDirectory>
+                        <outputDirectory>${basedir}/target/mapstore</outputDirectory>
                         <encoding>UTF-8</encoding>
                         <resources>
                             <resource>
@@ -179,7 +179,7 @@
                         <goal>copy-resources</goal>
                     </goals>
                     <configuration>
-                        <outputDirectory>${basedir}/target/GeOrchestra</outputDirectory>
+                        <outputDirectory>${basedir}/target/mapstore</outputDirectory>
                         <encoding>UTF-8</encoding>
                         <resources>
                             <resource>
@@ -202,7 +202,7 @@
                         <goal>copy-resources</goal>
                     </goals>
                     <configuration>
-                        <outputDirectory>${basedir}/target/GeOrchestra</outputDirectory>
+                        <outputDirectory>${basedir}/target/mapstore</outputDirectory>
                         <encoding>UTF-8</encoding>
                         <resources>
                             <resource>
@@ -225,7 +225,7 @@
                         <goal>copy-resources</goal>
                     </goals>
                     <configuration>
-                        <outputDirectory>${basedir}/target/GeOrchestra</outputDirectory>
+                        <outputDirectory>${basedir}/target/mapstore</outputDirectory>
                         <encoding>UTF-8</encoding>
                         <resources>
                             <resource>
@@ -248,7 +248,7 @@
                         <goal>copy-resources</goal>
                     </goals>
                     <configuration>
-                        <outputDirectory>${basedir}/target/GeOrchestra</outputDirectory>
+                        <outputDirectory>${basedir}/target/mapstore</outputDirectory>
                         <encoding>UTF-8</encoding>
                         <resources>
                             <resource>
@@ -278,7 +278,7 @@
                         <goal>copy-resources</goal>
                     </goals>
                     <configuration>
-                        <outputDirectory>${basedir}/target/GeOrchestra/dist</outputDirectory>
+                        <outputDirectory>${basedir}/target/mapstore/dist</outputDirectory>
                         <encoding>UTF-8</encoding>
                         <resources>
                             <resource>
@@ -294,7 +294,7 @@
                         <goal>copy-resources</goal>
                     </goals>
                     <configuration>
-                        <outputDirectory>${basedir}/target/GeOrchestra/assets</outputDirectory>
+                        <outputDirectory>${basedir}/target/mapstore/assets</outputDirectory>
                         <encoding>UTF-8</encoding>
                         <resources>
                             <resource>
@@ -310,7 +310,7 @@
                         <goal>copy-resources</goal>
                     </goals>
                     <configuration>
-                        <outputDirectory>${basedir}/target/GeOrchestra/MapStore2/web/client</outputDirectory>
+                        <outputDirectory>${basedir}/target/mapstore/MapStore2/web/client</outputDirectory>
                         <encoding>UTF-8</encoding>
                         <resources>
                             <resource>
@@ -335,7 +335,7 @@
                         <goal>copy-resources</goal>
                     </goals>
                     <configuration>
-                        <outputDirectory>${basedir}/target/GeOrchestra</outputDirectory>
+                        <outputDirectory>${basedir}/target/mapstore</outputDirectory>
                         <encoding>UTF-8</encoding>
                         <resources>
                             <resource>
@@ -354,7 +354,7 @@
                         <goal>copy-resources</goal>
                     </goals>
                     <configuration>
-                        <outputDirectory>${basedir}/target/GeOrchestra/printing</outputDirectory>
+                        <outputDirectory>${basedir}/target/mapstore/printing</outputDirectory>
                         <encoding>UTF-8</encoding>
                         <resources>
                             <resource>
@@ -373,7 +373,7 @@
                         <goal>copy-resources</goal>
                     </goals>
                     <configuration>
-                        <outputDirectory>${basedir}/target/GeOrchestra/MapStore2/web/client</outputDirectory>
+                        <outputDirectory>${basedir}/target/mapstore/MapStore2/web/client</outputDirectory>
                         <encoding>UTF-8</encoding>
                         <resources>
                             <resource>
@@ -392,7 +392,7 @@
                         <goal>copy-resources</goal>
                     </goals>
                     <configuration>
-                        <outputDirectory>${basedir}/target/GeOrchestra/MapStore2/web/client/libs/cesium-navigation</outputDirectory>
+                        <outputDirectory>${basedir}/target/mapstore/MapStore2/web/client/libs/cesium-navigation</outputDirectory>
                         <encoding>UTF-8</encoding>
                         <resources>
                             <resource>
@@ -408,7 +408,7 @@
                         <goal>copy-resources</goal>
                     </goals>
                     <configuration>
-                        <outputDirectory>${basedir}/target/GeOrchestra/MapStore2/web/client</outputDirectory>
+                        <outputDirectory>${basedir}/target/mapstore/MapStore2/web/client</outputDirectory>
                         <encoding>UTF-8</encoding>
                         <resources>
                             <resource>
@@ -456,7 +456,7 @@
             <version>6.1.20</version>
             <configuration>
                 <webAppConfig>
-                    <contextPath>/GeOrchestra</contextPath>
+                    <contextPath>/geOrchestra</contextPath>
                 </webAppConfig>
                 <connectors>
                     <connector implementation="org.mortbay.jetty.nio.SelectChannelConnector">

--- a/web/src/main/resources/geostore-spring-security.xml
+++ b/web/src/main/resources/geostore-spring-security.xml
@@ -45,12 +45,12 @@
             <property name="validateUserFromService" value="false"/>
 	</bean>
 
-    <!-- GeOrchestra header based Auth Provider -->
+    <!-- geOrchestra header based Auth Provider -->
 	<bean id="georchestraAuthenticationProvider"
 		class="it.geosolutions.geostore.services.rest.security.PreAuthenticatedAuthenticationProvider">
 	</bean>
 
-    <!-- GeOrchestra header based Auth Filter -->
+    <!-- geOrchestra header based Auth Filter -->
     <bean class="it.geosolutions.geostore.services.rest.security.HeadersAuthenticationFilter"
         id="headersProcessingFilter">
             <property name="addEveryOneGroup" value="true"/>
@@ -65,7 +65,7 @@
             </property>
 	</bean>
 
-    <!-- GeOrchestra groups to roles mapper for Headers Auth Filter -->
+    <!-- geOrchestra groups to roles mapper for Headers Auth Filter -->
     <bean id="rolesMapper" class="it.geosolutions.geostore.core.security.SimpleGrantedAuthoritiesMapper">
         <constructor-arg>
             <map>
@@ -74,7 +74,7 @@
         </constructor-arg>
     </bean>
 
-	<!-- Inject into the Authentication Manager the GeOrchestra Auth Provider -->
+	<!-- Inject into the Authentication Manager the geOrchestra Auth Provider -->
 	<security:authentication-manager>
         <security:authentication-provider ref='georchestraAuthenticationProvider' />
 	</security:authentication-manager>
@@ -82,7 +82,7 @@
     <!-- SecurityDAO using externals users -->
     <alias name="externalSecurityDAO" alias="securityDAO"/>
 
-    <!-- GeOrchestra LDAP DAOs -->
+    <!-- geOrchestra LDAP DAOs -->
     <bean id="ldap-context" class="org.springframework.security.ldap.DefaultSpringSecurityContextSource">
 		<constructor-arg value="${ldapScheme:ldap}://${ldapHost:localhost}:${ldapPort:389}/${ldapBaseDn:}" />
         <property name="userDn" value="${ldapAdminDn:admin}"/>

--- a/web/src/main/webapp/WEB-INF/web.xml
+++ b/web/src/main/webapp/WEB-INF/web.xml
@@ -10,7 +10,7 @@
             classpath*:applicationContext.xml
         </param-value>
 	</context-param>
-    <display-name>GeOrchestra - Web App</display-name>
+    <display-name>geOrchestra - Web App</display-name>
 	<context-param>
         <param-name>webAppRootKey</param-name>
         <param-value>geostore.root</param-value>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,8 +8,8 @@ const DEV_HOST = "georchestra.geo-solutions.it";
 
 module.exports = require("./MapStore2/build/buildConfig")(
     {
-        GeOrchestra: path.join(__dirname, "js", "app"),
-        "GeOrchestra-embedded": path.join(
+        geOrchestra: path.join(__dirname, "js", "app"),
+        "geOrchestra-embedded": path.join(
             __dirname,
             "MapStore2",
             "web",
@@ -17,7 +17,7 @@ module.exports = require("./MapStore2/build/buildConfig")(
             "product",
             "embedded"
         ),
-        "GeOrchestra-api": path.join(
+        "geOrchestra-api": path.join(
             __dirname,
             "MapStore2",
             "web",
@@ -39,7 +39,7 @@ module.exports = require("./MapStore2/build/buildConfig")(
     extractThemesPlugin,
     false,
     "dist/",
-    ".GeOrchestra",
+    ".geOrchestra",
     [],
     {
         "@mapstore": path.resolve(__dirname, "MapStore2", "web", "client"),
@@ -72,7 +72,7 @@ module.exports = require("./MapStore2/build/buildConfig")(
             }
         },
         "/proxy": {
-            // proxy of GeOrchestra is already configured
+            // proxy of geOrchestra is already configured
             target: `${DEV_PROTOCOL}://${DEV_HOST}/mapstore`,
             secure: false,
             headers: {


### PR DESCRIPTION
This PR contains fixes on various strings in the project.
#2 
- changes all "GeOrchestra" to geOrchestra.
- changes the name of the finar `war` file from `GeOrchestra.war` to `mapstore.war` (because this is the final name of the war used).

Only the `package.json` now contains a `georchestra` string in package name, because it's standard for npm package to be all lower case. Of course all the strings with `somethingGeOrchestra`  will remain with capital `G`, because the capital indicates the separation between words

#287
- Replace loading spinner from "Loading geOrchestra" to "Loading"
- Window title from "geOrchestra" to "GeOrchestra Viewer".