### PR TITLE
Fix table and hibernate_sequence access denied

### DIFF
--- a/database/001_mapstore.sql
+++ b/database/001_mapstore.sql
@@ -215,4 +215,7 @@ INSERT into gs_category (id ,name) values (6, 'USERSESSION');
 INSERT into gs_category (id ,name) values (7, 'GEOSTORY');
 INSERT into gs_category (id ,name) values (8, 'CONTEXT');
 
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA mapstore TO georchestra;
+GRANT USAGE, SELECT ON SEQUENCE hibernate_sequence TO georchestra;
+
 COMMIT;


### PR DESCRIPTION
This PR fix #310 and allow to create and save context with install from ansible without docker (not yet reproduced with others env).