### PR TITLE
#332 Removed tools locate (now injected by plugin)

### DIFF
--- a/localConfig.json
+++ b/localConfig.json
@@ -235,8 +235,7 @@
                           "altShiftDragRotate": false
                         }
                       }
-                    },
-                    "tools": ["locate"]
+                    }
                 }
             }, "Version", "DrawerMenu",
             {


### PR DESCRIPTION
Accordingly to this issue https://github.com/geosolutions-it/MapStore2/issues/6477 `tools` is now an invalid property. Removing solves the problem identified in #332