### PR TITLE
[Backport 1.2.x] #332 Removed tools locate (now injected by plugin) (#333)

### DIFF
--- a/localConfig.json
+++ b/localConfig.json
@@ -235,8 +235,7 @@
                           "altShiftDragRotate": false
                         }
                       }
-                    },
-                    "tools": ["locate"]
+                    }
                 }
             }, "Version", "DrawerMenu",
             {


### PR DESCRIPTION
[Backport 1.2.x] #332 Removed tools locate (now injected by plugin) (#333)