### PR TITLE
#347 add embedded configuration with GoFull button

### DIFF
--- a/localConfig.json
+++ b/localConfig.json
@@ -590,6 +590,133 @@
             "SaveAs",
             "MapCatalog"
         ],
+        "embedded": ["Details",
+          {
+            "name": "Map",
+            "cfg": {
+              "mapOptions": {
+                "openlayers": {
+                  "interactions": {
+                    "pinchRotate": false,
+                    "altShiftDragRotate": false
+                  },
+                  "attribution": {
+                    "container": "#footer-attribution-container"
+                  }
+                },
+                "leaflet": {
+                  "attribution": {
+                    "container": "#footer-attribution-container"
+                  }
+                }
+              },
+              "toolsOptions": {
+                "scalebar": {
+                  "container": "#footer-scalebar-container"
+                }
+              }
+            }
+          },
+          {
+            "name": "DrawerMenu",
+            "hide": "{!(request.query && request.query.forceDrawer)}"
+          },
+          {
+            "name": "BackgroundSelector",
+            "cfg": {
+              "bottom": 40,
+              "dimensions": {
+                "side": 65,
+                "sidePreview": 65,
+                "frame": 3,
+                "margin": 5,
+                "label": false,
+                "vertical": true
+              }
+            }
+          },
+          {
+            "name": "Identify",
+            "cfg": {
+              "showFullscreen": true,
+              "position": "bottom",
+              "size": 0.5,
+              "fluid": true,
+              "viewerOptions": {
+                "container": "{context.ReactSwipe}"
+              }
+            }
+          },
+          {
+            "name": "ZoomAll",
+            "override": {
+              "Toolbar": {
+                "alwaysVisible": true
+              }
+            }
+          },
+          {
+            "name": "Locate",
+            "override": {
+              "Toolbar": {
+                "alwaysVisible": true
+              }
+            }
+          },
+          {
+            "name": "TOC",
+            "cfg": {
+              "activateMapTitle": false,
+              "activateSettingsTool": false,
+              "activateMetedataTool": false,
+              "activateRemoveLayer": false
+            }
+          },
+          "AddGroup",
+          "MapFooter",
+          {
+            "name": "Settings",
+            "cfg": {
+              "wrap": true
+            }
+          },
+          {
+            "name": "Search",
+            "cfg": {
+              "showOptions": false,
+              "withToggle": [
+                "max-width: 768px",
+                "min-width: 768px"
+              ]
+            }
+          },
+          {
+            "name": "Toolbar",
+            "id": "NavigationBar",
+            "cfg": {
+              "id": "navigationBar"
+            }
+          },
+          {
+            "name": "MapLoading",
+            "override": {
+              "Toolbar": {
+                "alwaysVisible": true
+              }
+            }
+          },
+          "Cookie",
+          "OmniBar",
+          {
+            "name": "GoFull",
+            "override": {
+              "Toolbar": {
+                "alwaysVisible": true
+              }
+            }
+          },
+          "FeedbackMask"
+        ],
         "common": [],
         "maps": [
           "Login",

--- a/localConfig.json
+++ b/localConfig.json
@@ -705,7 +705,13 @@
               }
             }
           },
-          "Cookie",
+          {
+            "name": "Cookie",
+            "cfg": {
+              "externalCookieUrl": "https://docs.georchestra.geo-solutions.it/en/latest/mapstore/index.html",
+              "declineUrl": "https://www.georchestra.org/"
+            }
+          },
           "OmniBar",
           {
             "name": "GoFull",


### PR DESCRIPTION
This PR adds to `localConfig.json` the embedded configuration, with "GoFull" plugin.

"Note": GoFull in "embedded" is intended to be used only in embedded maps (without context).