### PR TITLE
#351: Fix issue with localStorage in incognito mode

### DIFF
--- a/js/app.jsx
+++ b/js/app.jsx
@@ -42,6 +42,8 @@ ConfigUtils.setConfigProp("extensionsRegistry", "rest/config/load/extensions.jso
 ConfigUtils.setConfigProp("contextPluginsConfiguration", "rest/config/load/pluginsConfig.json");
 ConfigUtils.setConfigProp("extensionsFolder", "rest/config/loadasset/");
 ConfigUtils.setConfigProp("configurationFolder", "rest/config/load/");
+import { getApi } from '../MapStore2/web/client/api/userPersistedStorage';
+
 
 Providers.georchestra = serverbackup;
 
@@ -116,7 +118,7 @@ const appPlugins = {
 };
 
 const start = userInfo => {
-    localStorage.setItem(
+    getApi().setItem(
         "mapstore2.persist.security",
         JSON.stringify(userInfo)
     );


### PR DESCRIPTION
This issue solves the problem of iframe + incognito mode caused by localStorage not accessible (depending on 3rd party cookies enable).
Draft until [this issue ](https://github.com/geosolutions-it/MapStore2/issues/6651) is solved (by [this](https://github.com/geosolutions-it/MapStore2/pull/6820) PR on master,  that need to be backported.

