### PR TITLE
pushing tags (releases) docker images to docker hub

### DIFF
--- a/.github/workflows/mapstore.yml
+++ b/.github/workflows/mapstore.yml
@@ -89,3 +89,8 @@ jobs:
         docker tag georchestra/mapstore:${{ steps.version.outputs.VERSION }} georchestra/mapstore:latest
         docker push georchestra/mapstore:latest
       working-directory: ${{ github.workspace }}
+
+    - name: "Pushing tag to docker.io"
+      if: contains(github.ref, 'refs/tags/') && github.repository == 'georchestra/mapstore2-georchestra'
+      run: |
+        docker push georchestra/mapstore:${{ steps.version.outputs.VERSION }}


### PR DESCRIPTION
In order to synchronize this repository with geOrchestra releases, I suggest to push the generated docker images issued by a created tag.

I did a try with a tag '20.1.3-georchestra' without checking the push step will only be executed when executed on the master branche, hence this PR.
