### PR TITLE
localConfig.json: add some IGN geoservices to defaults

### DIFF
--- a/configs/localConfig.json
+++ b/configs/localConfig.json
@@ -149,12 +149,6 @@
                 "title": "IGN essentiels WMTS",
                 "autoload": true
               },
-              "ignwfs": {
-                "url": "https://wxs.ign.fr/essentiels/geoportail/wfs",
-                "type": "wfs",
-                "title": "IGN essentiels WFS",
-                "autoload": true
-              },
               "igndecouvertewmts": {
                 "url": "https://wxs.ign.fr/decouverte/geoportail/wmts",
                 "type": "wmts",

--- a/configs/localConfig.json
+++ b/configs/localConfig.json
@@ -131,6 +131,36 @@
                 "title": "le geoserver local",
                 "autoload": true
               },
+              "ignrasterwms": {
+                "url": "https://wxs.ign.fr/essentiels/geoportail/r/wms",
+                "type": "wms",
+                "title": "IGN essentiels RASTER",
+                "autoload": true
+              },
+              "ignvectorwms": {
+                "url": "https://wxs.ign.fr/essentiels/geoportail/v/wms",
+                "type": "wms",
+                "title": "IGN essentiels VECTOR",
+                "autoload": true
+              },
+              "ignwmts": {
+                "url": "https://wxs.ign.fr/essentiels/geoportail/wmts",
+                "type": "wmts",
+                "title": "IGN essentiels WMTS",
+                "autoload": true
+              },
+              "ignwfs": {
+                "url": "https://wxs.ign.fr/essentiels/geoportail/wfs",
+                "type": "wfs",
+                "title": "IGN essentiels WFS",
+                "autoload": true
+              },
+              "igndecouvertewmts": {
+                "url": "https://wxs.ign.fr/decouverte/geoportail/wmts",
+                "type": "wmts",
+                "title": "IGN decouverte WMTS",
+                "autoload": true
+              },
               "geobretagne": {
                 "url": "https://geobretagne.fr/geonetwork/srv/fre/csw",
                 "type": "csw",

--- a/configs/localConfig.json
+++ b/configs/localConfig.json
@@ -155,6 +155,36 @@
                 "title": "IGN decouverte WMTS",
                 "autoload": true
               },
+              "igncartovectowms": {
+                "url": "https://wxs.ign.fr/cartovecto/geoportail/v/wms",
+                "type": "wms",
+                "title": "IGN carto vectorielle",
+                "autoload": true
+              },
+              "ignadministratifwms": {
+                "url": "https://wxs.ign.fr/administratif/geoportail/r/wms",
+                "type": "wms",
+                "title": "IGN administratif",
+                "autoload": true
+              },
+              "ignadressewms": {
+                "url": "https://wxs.ign.fr/adresse/geoportail/v/wms",
+                "type": "wms",
+                "title": "IGN adresse",
+                "autoload": true
+              },
+              "ignagriculturewms": {
+                "url": "https://wxs.ign.fr/agriculture/geoportail/r/wms",
+                "type": "wms",
+                "title": "IGN agriculture",
+                "autoload": true
+              },
+              "ignaltimetriewmts": {
+                "url": "https://wxs.ign.fr/altimetrie/geoportail/wmts",
+                "type": "wmts",
+                "title": "IGN altimetrie WMTS",
+                "autoload": true
+              },
               "geobretagne": {
                 "url": "https://geobretagne.fr/geonetwork/srv/fre/csw",
                 "type": "csw",


### PR DESCRIPTION
those have recently be opened up by IGN, cf (among others) https://geoservices.ign.fr/services-web-decouverte and https://geoservices.ign.fr/services-web-essentiels (https://geoservices.ign.fr/services-web-experts could be interesting too, i but i dont think the altimetry service would work for cesium/globe view)

i've been able to successfully test loading WMS and WMTS raster layers, and they worked ootb without having to fiddle with obscure query parameters. For some reason https://wxs.ign.fr/essentiels/geoportail/v/wms?service=WMS&version=1.3.0&request=GetCapabilities doesnt load in mapstore/timeouts.. and some of the services are redundant, this PR is mostly here to open discussion about whether some national services/layers should be added by default (i personally think it would be nice for ppl testing georchestra/mapstore) 

WFS layer can be added but displays nothing, and the attribute table is not working... still shows how mapstore has an adherence to geoserver ;)

btw, some of the layers could also be added as default backgrounds for everyone...

cc @fvanderbiest @catmorales @MaelREBOUX @pierrejego @jusabatier