### PR TITLE
Switch Mapstore2 submodule to georchestra fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "MapStore2"]
 	path = MapStore2
-	url = https://github.com/geosolutions-it/MapStore2.git
+	url = https://github.com/georchestra/MapStore2.git


### PR DESCRIPTION
This PR switches the Mapstore2 submodule to a georchestra branch of the georchestra fork of Mapstore2. This allows to integrate recent developments that have been accepted and merged into Mapstore2 until updating the submodules to branch `2021.02.xx` which involves more obstacles.