### PR TITLE
#402 Made Version Repo-URLs configurable

### DIFF
--- a/js/plugins/Version.jsx
+++ b/js/plugins/Version.jsx
@@ -27,11 +27,15 @@ const Version = connect((state) => ({
 }))(
     class extends React.Component {
         static propTypes = {
-            version: PropTypes.string
+            version: PropTypes.string,
+            urlRepo: PropTypes.string,
+            urlSubmodule: PropTypes.string
         };
 
         static defaultProps = {
-            version: "DEV"
+            version: "DEV",
+            urlRepo: "https://github.com/georchestra/mapstore2-georchestra",
+            urlSubmodule: "https://github.com/geosolutions-it/MapStore2"
         };
 
         renderUrl = (baseUrl, hash, type = "commit") => {
@@ -47,11 +51,11 @@ const Version = connect((state) => ({
             const [
                 hashRepo = "",
                 branchRepo = "",
-                urlRepo = "",
-                hashSubmodule = "",
-                urlSubmodule = ""
+                hashSubmodule = ""
                 // eslint-disable-next-line no-undef
             ] = __VERSIONINFO__ || [];
+            const {urlRepo, urlSubmodule} = this.props;
+
             const _hashSubmodule = hashSubmodule.trim().split(" ")[0];
             const versionSubmodule = this.props.version || "";
             return (

--- a/revision.js
+++ b/revision.js
@@ -5,13 +5,13 @@ const parseCommand = () => {
     const commands = [
         'rev-parse HEAD', // Repository commit hash
         'rev-parse --abbrev-ref HEAD', // Repository branch name
-        'remote get-url origin', // Repository url
-        'submodule status', // Submodule info
-        'submodule foreach -q git config remote.origin.url' // Submodule url
+        // 'remote get-url origin', // Repository url
+        'submodule status' // Submodule info
+        // 'submodule foreach -q git config remote.origin.url' // Submodule url
     ]
     return commands.map(command => JSON.stringify(
         new GitRevisionPlugin({
-            branchCommand: command,
+            branchCommand: command
         }).branch()
     ));
 };


### PR DESCRIPTION
Changed the repo-url and submodule-url in Version plugin to be get from configuration, and not by URL command.
This to avoid old versions of git to fail and to make it more stable (remotes can be customized, origin doesn't always indicate the current repo).