### PR TITLE
Update to latest stable (Street View)

### DIFF
--- a/configs/pluginsConfig.json
+++ b/configs/pluginsConfig.json
@@ -553,6 +553,12 @@
       "title": "plugins.UserSession.title",
       "description": "plugins.UserSession.description",
       "dependencies": ["BurgerMenu"]
+    }, {
+      "name": "StreetView",
+      "glyph": "road",
+      "title": "plugins.StreetView.title",
+      "description": "plugins.StreetView.description",
+      "dependencies": ["Toolbar"]
     }
   ]
 }


### PR DESCRIPTION
With this PR Street view extension is not necessary anymore.
The street view tool is pulled directly from MapStore stable branch.