### PR TITLE
Reduce the context to load at build time

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+**
+!web/target
+!docker


### PR DESCRIPTION
Using .dockerignore file allows to reduce drastically the context loading on the docker build (1,5G -> 200Mb)