### PR TITLE
[docker] Run tomcat as non-root user

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+**
+!web/target
+!docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,13 @@ RUN if [ "$TOMCAT_EXTRAS" = false ]; then \
       find "${CATALINA_BASE}/webapps/" -delete; \
     fi
 
+# Create a non-privileged tomcat user
+RUN addgroup --gid 999 tomcat && \
+    adduser --system  -u 999 --gid 999 --no-create-home tomcat && \
+    chown -R 999:999 /usr/local/tomcat
+
 # Add war files to be deployed
-COPY docker/*.war "${CATALINA_BASE}/webapps/mapstore.war"
+COPY --chown=999:999 web/target/mapstore.war "${CATALINA_BASE}/webapps/mapstore.war"
 
 # Geostore externalization template. Disabled by default
 # COPY docker/geostore-datasource-ovr.properties "${CATALINA_BASE}/conf/"
@@ -22,5 +27,7 @@ ENV JAVA_OPTS="${JAVA_OPTS} ${GEORCHESTRA_DATADIR_OPT}"
 
 # Set variable to better handle terminal commands
 ENV TERM xterm
+
+USER tomcat
 
 EXPOSE 8080


### PR DESCRIPTION
All georchestra images run as a non-privileged user (uid 999). For a better consistency, and better security practices, I propose we do the same here, run the tomcat server as non-privileged user 999

Addresses https://github.com/georchestra/mapstore2-georchestra/issues/403