### PR TITLE
deb - fixing webapp generation

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -15,6 +15,7 @@
     <skip.npm>true</skip.npm>
     <skip.karma>true</skip.karma>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <resources.output.dir>${basedir}/target/mapstore</resources.output.dir>
   </properties>
   <dependencies>
     <!-- MapStore backend -->
@@ -94,7 +95,7 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
-              <outputDirectory>${basedir}/target/mapstore</outputDirectory>
+              <outputDirectory>${resources.output.dir}</outputDirectory>
               <encoding>UTF-8</encoding>
               <resources>
                 <resource>
@@ -114,7 +115,7 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
-              <outputDirectory>${basedir}/target/mapstore</outputDirectory>
+              <outputDirectory>${resources.output.dir}</outputDirectory>
               <encoding>UTF-8</encoding>
               <resources>
                 <resource>
@@ -137,7 +138,7 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
-              <outputDirectory>${basedir}/target/mapstore</outputDirectory>
+              <outputDirectory>${resources.output.dir}</outputDirectory>
               <encoding>UTF-8</encoding>
               <resources>
                 <resource>
@@ -160,7 +161,7 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
-              <outputDirectory>${basedir}/target/mapstore</outputDirectory>
+              <outputDirectory>${resources.output.dir}</outputDirectory>
               <encoding>UTF-8</encoding>
               <resources>
                 <resource>
@@ -183,7 +184,7 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
-              <outputDirectory>${basedir}/target/mapstore</outputDirectory>
+              <outputDirectory>${resources.output.dir}</outputDirectory>
               <encoding>UTF-8</encoding>
               <resources>
                 <resource>
@@ -196,6 +197,9 @@
                   </includes>
                   <excludes>
                     <exclude>node_modules/*</exclude>
+                    <exclude>node/**/*</exclude>
+                    <exclude>web/**/*</exclude>
+                    <exclude>coverage/**/*</exclude>
                     <exclude>node_modules/**/*</exclude>
                     <exclude>MapStore2/*</exclude>
                     <exclude>MapStore2/**/*</exclude>
@@ -213,7 +217,7 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
-              <outputDirectory>${basedir}/target/mapstore/dist</outputDirectory>
+              <outputDirectory>${resources.output.dir}/dist</outputDirectory>
               <encoding>UTF-8</encoding>
               <resources>
                 <resource>
@@ -229,7 +233,7 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
-              <outputDirectory>${basedir}/target/mapstore/assets</outputDirectory>
+              <outputDirectory>${resources.output.dir}/assets</outputDirectory>
               <encoding>UTF-8</encoding>
               <resources>
                 <resource>
@@ -245,7 +249,7 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
-              <outputDirectory>${basedir}/target/mapstore/MapStore2/web/client</outputDirectory>
+              <outputDirectory>${resources.output.dir}/MapStore2/web/client</outputDirectory>
               <encoding>UTF-8</encoding>
               <resources>
                 <resource>
@@ -270,7 +274,7 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
-              <outputDirectory>${basedir}/target/mapstore</outputDirectory>
+              <outputDirectory>${resources.output.dir}</outputDirectory>
               <encoding>UTF-8</encoding>
               <resources>
                 <resource>
@@ -289,7 +293,7 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
-              <outputDirectory>${basedir}/target/mapstore/printing</outputDirectory>
+              <outputDirectory>${resources.output.dir}/printing</outputDirectory>
               <encoding>UTF-8</encoding>
               <resources>
                 <resource>
@@ -308,7 +312,7 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
-              <outputDirectory>${basedir}/target/mapstore/MapStore2/web/client</outputDirectory>
+              <outputDirectory>${resources.output.dir}/MapStore2/web/client</outputDirectory>
               <encoding>UTF-8</encoding>
               <resources>
                 <resource>
@@ -327,7 +331,7 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
-              <outputDirectory>${basedir}/target/mapstore/MapStore2/web/client/libs/cesium-navigation</outputDirectory>
+              <outputDirectory>${resources.output.dir}/MapStore2/web/client/libs/cesium-navigation</outputDirectory>
               <encoding>UTF-8</encoding>
               <resources>
                 <resource>
@@ -343,7 +347,7 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
-              <outputDirectory>${basedir}/target/mapstore/MapStore2/web/client</outputDirectory>
+              <outputDirectory>${resources.output.dir}/MapStore2/web/client</outputDirectory>
               <encoding>UTF-8</encoding>
               <resources>
                 <resource>
@@ -365,11 +369,11 @@
           <packagingExcludes>WEB-INF/lib/commons-codec-1.2.jar,
                 WEB-INF/lib/commons-io-1.1.jar,
                 WEB-INF/lib/commons-logging-1.0.4.jar,
-		WEB-INF/lib/commons-pool-1.3.jar,
-		WEB-INF/lib/spring-*-3.1.0*.jar,
+                WEB-INF/lib/commons-pool-1.3.jar,
+                WEB-INF/lib/spring-*-3.1.0*.jar,
                 WEB-INF/classes/geostore-datasource-ovr.properties,
                 WEB-INF/classes/geostore-ovr.properties
-                </packagingExcludes>
+          </packagingExcludes>
           <overlays>
             <overlay>
               <groupId>it.geosolutions.geostore</groupId>
@@ -405,6 +409,9 @@
     <profiles>
         <profile>
             <id>debianPackage</id>
+            <properties>
+                <resources.output.dir>${basedir}/target/mapstore-generic</resources.output.dir>
+            </properties>
             <build>
                 <finalName>mapstore-generic</finalName>
                 <plugins>


### PR DESCRIPTION
This fixes a previous work from PR #407 ; the maven-resources-plugins copies resources to target/mapstore, but the debianPackage maven profile expects to generate a war file from target/mapstore-generic (as stated in the previous mentioned PR, this is a convention used in the other webapps from geOrchestra).

This commit suggests to externalize the target directory for resources to a variable, which is then overriden in the `debianPackage` maven profile.

It also adds extra resources to be excluded while copying. e.g if the maven-frontend-plugin is used, then a node/ subdirectory is created, we don't need it in the generated webapp, so it has been added to the excludes list, same for coverage.

Note: since no CI has been set up yet to generate the debian package, this is probably the reason why this bug hasn't been tracked down.

tests: checking against the mapstore.war coming from the `geosolutions-it/mapstore:latest` docker image, there also seems to contain an unecessary web/ directory:

```
    testing: web/                     OK
    testing: web/target/mapstore/embedded.html   OK
    testing: web/target/mapstore/index.html   OK
    testing: web/target/mapstore/     OK
    testing: web/target/              OK
```

both embedded.html & index.html are nested in the dist/ subdirectory of the war file anyway.