### PR TITLE
publish a debian package artifact via gh-actions

### DIFF
--- a/.github/workflows/mapstore.yml
+++ b/.github/workflows/mapstore.yml
@@ -55,6 +55,18 @@ jobs:
     - name: "package with Maven"
       run: mvn -B clean install -Dmapstore2.version=${{ github.sha }}
 
+    - name: "debian package with Maven"
+      run: mvn -B package deb:package -pl web -PdebianPackage
+
+    - name: "copy resulting deb"
+      run: mkdir -p scratch && cp web/target/georchestra-mapstore*.deb scratch/georchestra-mapstore-${{ github.sha }}.deb
+
+    - name: "publish deb as artifact"
+      uses: actions/upload-artifact@v1
+      with:
+        name: georchestra-mapstore.deb
+        path: scratch/georchestra-mapstore-${{ github.sha }}.deb
+
     - name: "copy resulting war"
       run: mkdir -p scratch && cp web/target/mapstore.war scratch/mapstore-${{ github.sha }}.war
 

--- a/.github/workflows/mapstore.yml
+++ b/.github/workflows/mapstore.yml
@@ -7,11 +7,10 @@ jobs:
     steps:
     - name: "checking out"
       uses: actions/checkout@v2
-    - name: Checkout submodules
-      run: |
-        auth_header="$(git config --local --get http.https://github.com/.extraheader)"
-        git submodule sync --recursive
-        git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+      with:
+        # 0 gets tags, needed for debian package
+        fetch-depth: 0
+        submodules: 'recursive'
 
     - name: "setting up Java"
       uses: actions/setup-java@v1


### PR DESCRIPTION
made possible by #446, while here improve `actions/checkout` usage for submodules