### PR TITLE
use the same debian package version conventions as in georchestra (#463)

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -16,6 +16,7 @@
     <skip.karma>true</skip.karma>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <resources.output.dir>${basedir}/target/mapstore</resources.output.dir>
+    <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
   </properties>
   <dependencies>
     <!-- MapStore backend -->
@@ -497,6 +498,21 @@
                                     <goal>run</goal>
                                 </goals>
                             </execution>
+                            <execution>
+                                <id>set-project-packageversion</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <exportAntProperties>true</exportAntProperties>
+                                    <target>
+                                        <condition property="branchVersion" value="99.master" else="${build.branch}">
+                                            <matches string="${build.branch}" pattern="master" />
+                                        </condition>
+                                    </target>
+                                </configuration>
+                            </execution>
                         </executions>
                     </plugin>
                     <plugin>
@@ -505,8 +521,7 @@
                         <version>1.0.6</version>
                         <configuration>
                             <packageName>georchestra-mapstore</packageName>
-                            <packageVersion>${build.closest.tag.name}</packageVersion>
-                            <packageRevision>${build.closest.tag.commit.count}</packageRevision>
+                            <packageVersion>${branchVersion}.${maven.build.timestamp}~${build.commit.id.abbrev}</packageVersion>
                             <packageDescription>geOrchestra Mapstore</packageDescription>
                             <projectOrganization>geOrchestra</projectOrganization>
                             <maintainerName>PSC</maintainerName>


### PR DESCRIPTION
reworks what was done in #407, use the branch to determine if we're on master
or not, prepend 99 if that's the case, and use maven timestamp and short git
commit sha.