### PR TITLE
Pedastrian view and WMTS fixes

### DIFF
--- a/configs/pluginsConfig.json
+++ b/configs/pluginsConfig.json
@@ -565,7 +565,12 @@
       "glyph": "road",
       "title": "plugins.StreetView.title",
       "description": "plugins.StreetView.description",
-      "dependencies": ["Toolbar"]
+      "dependencies": ["Toolbar"],
+      "defaultConfig": {
+        "panoramaOptions": {
+          "imageDateControl": true
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
This PR adds fixes for:
- #462 : adds configurability for panorama options (sets as default for
new contexts the `imageDateControl: true`
- #399 : Adding contribution by @landryb to WMTS print option