### PR TITLE
make sure apache-log4j-extras ends up in the war

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -79,6 +79,7 @@
         <groupId>log4j</groupId>
         <artifactId>apache-log4j-extras</artifactId>
         <version>1.2.17</version>
+      <scope>runtime</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
somehow what was done in #271 got lost in 195c2ad5f, and for some reason `apache-log4j-extras` isnt in the generated war.

with the default shipped log4j config, `org.apache.log4j.rolling.RollingFileAppender` doesnt exist and thus logging is broken.

@pmauduit do you know why not having `<scope>runtime</scope>` doesnt embed the jar in the war ?

i've tested locally that manually copying `apache-log4j-extras-1.2.17.jar` in a mapstore instance and reloading it restores working logging, which was broken for me since last february. b2803ecc partially restored it but apparently this wasnt enough to bundle the jar in the war.