### PR TITLE
force CI to build and tag on branch name (#3501)

### DIFF
--- a/.github/workflows/mapstore.yml
+++ b/.github/workflows/mapstore.yml
@@ -75,18 +75,13 @@ jobs:
         name: mapstore.war
         path: scratch/mapstore-${{ github.sha }}.war
 
-    - name: Getting image tag
-      if: github.repository == 'georchestra/mapstore2-georchestra'
-      id: version
-      run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
-
     - name: "Building docker image"
       if: github.repository == 'georchestra/mapstore2-georchestra'
       run: |
-        cp scratch/mapstore-${{ github.sha }}.war docker/MapStore-${{ steps.version.outputs.VERSION }}.war
-        docker build . -t georchestra/mapstore:${{ steps.version.outputs.VERSION }}
-        # mvn -B package dockerfile:build -Pdocker,log4j-logstash,sentry-log4j -DdockerImageName=georchestra/mapstore:${{ steps.version.outputs.VERSION }} -settings settings.xml
-      working-directory: ${{ github.workspace }}
+        cp scratch/mapstore-${{ github.sha }}.war docker/MapStore-${GITHUB_REF_NAME}.war
+        docker build . -t georchestra/mapstore:$GITHUB_REF_NAME
+        # mvn -B package dockerfile:build -Pdocker,log4j-logstash,sentry-log4j -DdockerImageName=georchestra/mapstore:$GITHUB_REF_NAME -settings settings.xml
+
     - name: "Logging in docker.io"
       if: github.repository == 'georchestra/mapstore2-georchestra' && github.event_name == 'push'
       uses: azure/docker-login@v1
@@ -97,11 +92,10 @@ jobs:
     - name: "Pushing latest to docker.io"
       if: github.ref == 'refs/heads/master' && github.repository == 'georchestra/mapstore2-georchestra' && github.event_name == 'push'
       run: |
-        docker tag georchestra/mapstore:${{ steps.version.outputs.VERSION }} georchestra/mapstore:latest
+        docker tag georchestra/mapstore:$GITHUB_REF_NAME georchestra/mapstore:latest
         docker push georchestra/mapstore:latest
-      working-directory: ${{ github.workspace }}
 
-    - name: "Pushing tag to docker.io"
-      if: contains(github.ref, 'refs/tags/') && github.repository == 'georchestra/mapstore2-georchestra' && github.event_name == 'push'
+    - name: "Pushing release to docker.io"
+      if: startWith(github.ref_name, '20') && github.repository == 'georchestra/mapstore2-georchestra' && github.event_name == 'push'
       run: |
-        docker push georchestra/mapstore:${{ steps.version.outputs.VERSION }}
+        docker push georchestra/mapstore:$GITHUB_REF_NAME


### PR DESCRIPTION
Fix georchestra/georchestra#3501

CI was not creating tagged images probably because it relied on git tags rather than branches
should work for both now.

Also includes some (harmless?) modifications of variables of the CI, `GITHUB_REF_NAME`, `VERSION` (which was equal to `github.ref_name`)

same PR to come on `mapstore2-georchestra/2022.02.xx` branch