### PR TITLE
move from tomcat to jetty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,17 @@
-FROM tomcat:7.0-jre8
-MAINTAINER geosolutions<info@geo-solutions.it>
+FROM jetty:9-jre11
 
-# Tomcat specific options
-ENV CATALINA_BASE "$CATALINA_HOME"
-ENV JAVA_OPTS="${JAVA_OPTS}  -Xms512m -Xmx512m -XX:MaxPermSize=128m"
-
-# Optionally remove Tomcat manager, docs, and examples
-ARG TOMCAT_EXTRAS=false
-RUN if [ "$TOMCAT_EXTRAS" = false ]; then \
-      find "${CATALINA_BASE}/webapps/" -delete; \
-    fi
+RUN java -jar "$JETTY_HOME/start.jar" --create-startd --add-to-start=jmx,jmx-remote,stats,http-forwarded
 
 # Add war files to be deployed
-COPY docker/*.war "${CATALINA_BASE}/webapps/mapstore.war"
+COPY web/target/*.war /var/lib/jetty/webapps/
 
 # Geostore externalization template. Disabled by default
-# COPY docker/geostore-datasource-ovr.properties "${CATALINA_BASE}/conf/"
+# COPY docker/geostore-datasource-ovr.properties "/var/lib/jetty/conf/"
 # ARG GEOSTORE_OVR_OPT=""
-ARG GEORCHESTRA_DATADIR_OPT="-Dgeorchestra.datadir=/etc/georchestra"
-ENV JAVA_OPTS="${JAVA_OPTS} ${GEORCHESTRA_DATADIR_OPT}"
+# georchestra datadir is defaulted to /etc/georchestra
+# might be overriden with -Dgeorchestra.datadir=/etc/georchestra
+# ARG GEORCHESTRA_DATADIR_OPT="-Dgeorchestra.datadir=/etc/georchestra"
 
-# Set variable to better handle terminal commands
-ENV TERM xterm
+# This is usually overriden in the docker-compose
+ENV JAVA_OPTIONS="-Xms512m -Xmx512m -DPRINT_BASE_URL=pdf -Dgeorchestra.datadir=/etc/georchestra"
 
-EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM jetty:9-jre11
+LABEL maintainers="geosolutions<info@geo-solutions.it>, geOrchestra<psc@georchestra.org>"
 
 RUN java -jar "$JETTY_HOME/start.jar" --create-startd --add-to-start=jmx,jmx-remote,stats,http-forwarded
 


### PR DESCRIPTION
It was discussed some time ago, we're trying to generalize `jetty` for the images of geOrchestra.

This PR focuses on moving from `tomcat` to the same version of `jetty` we use elsewhere in geOrchestra : `jetty:9-jre11`

a noticeable difference is the use of `JAVA_OPTIONS` instead of `JAVA_OPTS` . 
It might have an impact on docker-compose setups : https://github.com/georchestra/docker/blob/6bb2d39e0683dbe1523ad341f797173ed60fa4a5/docker-compose.yml#L173-L180

This image comes with settings that should work out of the box even if the composition are not up-to-date. (Xmx/Xms and `georchestra.datadir` set to reasonable values)