### PR TITLE
#514: Added SearchByBookmark plugin to config

### DIFF
--- a/configs/localConfig.json
+++ b/configs/localConfig.json
@@ -646,6 +646,7 @@
             "StyleEditor",
             "Save",
             "SaveAs",
+            "SearchByBookmark",
             "MapCatalog"
         ],
         "embedded": ["Details",


### PR DESCRIPTION
## Description
This PR adds plugin config to enable `SearchByBookmark` feature

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Enhancement

## Issue

**What is the current behavior?**
#514

**What is the new behavior?**
SearchByBookmark is enabled in desktop version. It follows the default permissioning ie. plugin is enabled and visible only when user is authenticated

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
