### PR TITLE
#515: Bottom tools layout fix in modal

### DIFF
--- a/themes/default/header.less
+++ b/themes/default/header.less
@@ -15,16 +15,30 @@
  * So this fixed position makes the position of the tools to be relative to the window too
  * and then also the percentage is relative to the same.
  */
-@geo-bottom-tools-position: fixed;
+@geo-bottom-tools-position-fixed: fixed;
+@geo-bottom-tools-position-absolute: absolute;
 .background-plugin-position {
-    position: @geo-bottom-tools-position !important;
+    position: @geo-bottom-tools-position-fixed;
 }
 .mapToolbar {
-    position: @geo-bottom-tools-position !important;
+    position: @geo-bottom-tools-position-fixed;
 }
 .timeline-plugin {
-    position: fixed !important;
+    position: @geo-bottom-tools-position-fixed;
 }
+// To fix overlap of bottom tools of map viewer in a modal
+.map-editor-modal-body {
+    .background-plugin-position {
+        position: @geo-bottom-tools-position-absolute;
+    }
+    .mapToolbar {
+        position: @geo-bottom-tools-position-absolute;
+    }
+    .timeline-plugin {
+        position: @geo-bottom-tools-position-absolute;
+    }
+}
+
 /*
  * CSS Used in geo-node integration, not yet used
  *


### PR DESCRIPTION
## Description
This PR adds fix to layout of bottom tools overlap when map viewer is displayed in modal

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

## Issue

**What is the current behavior?**
#515 

**What is the new behavior?**
![image](https://user-images.githubusercontent.com/26929983/165892308-e6d039e5-2d40-436f-bc5b-7df92ad00d1c.png)


## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
