### PR TITLE
#515: Timeline tool position fix

### DIFF
--- a/themes/default/header.less
+++ b/themes/default/header.less
@@ -24,7 +24,7 @@
     position: @geo-bottom-tools-position-fixed;
 }
 .timeline-plugin {
-    position: @geo-bottom-tools-position-fixed;
+    position: @geo-bottom-tools-position-fixed!important;
 }
 // To fix overlap of bottom tools of map viewer in a modal
 .map-editor-modal-body {


### PR DESCRIPTION
Ref: https://github.com/georchestra/mapstore2-georchestra/pull/517#issuecomment-1113241074

Fix for timeline tool layout when attribute table is opened.
Timeline plugin has inline style to apply position hence need to be overriden.

![image](https://user-images.githubusercontent.com/26929983/165944328-3b724cb2-60a1-4b87-8e23-d43466aac548.png)
