### PR TITLE
Activate print overlay layers capability by default

### DIFF
--- a/configs/localConfig.json
+++ b/configs/localConfig.json
@@ -541,6 +541,9 @@
                 "useFixedScales": true,
                 "mapPreviewOptions": {
                   "enableScalebox": true
+                },
+                "overlayLayersOptions": {
+                  "enabled": true
                 }
               }
             }, "MapImport", "MapExport", {

--- a/configs/pluginsConfig.json
+++ b/configs/pluginsConfig.json
@@ -285,7 +285,12 @@
       "description": "plugins.Print.description",
       "dependencies": [
         "SidebarMenu"
-      ]
+      ],
+      "defaultConfig": {
+        "overlayLayersOptions": {
+          "enabled": true
+        }
+      }
     },
     {
       "name": "MapCatalog",


### PR DESCRIPTION
This PR makes a slight change to configuration: an option to print overlay layers will be available by default in map viewer & will be preset by default to the printing module on context creation.