### PR TITLE
Integrate msIframe connector

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -82,6 +82,11 @@
       <artifactId>javax.servlet-api</artifactId>
       <version>3.0.1</version>
     </dependency>
+    <dependency>
+        <groupId>jstl</groupId>
+        <artifactId>jstl</artifactId>
+        <version>1.2</version>
+    </dependency>
     <!-- gzip compression filter -->
     <dependency>
       <groupId>net.sf.ehcache</groupId>

--- a/web/src/main/java/fr/lepuyenvelay/msiframe/MsIframeController.java
+++ b/web/src/main/java/fr/lepuyenvelay/msiframe/MsIframeController.java
@@ -1,0 +1,21 @@
+package fr.lepuyenvelay.msiframe;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.servlet.ModelAndView;
+
+@Controller
+public class MsIframeController {
+    @Autowired
+    Environment env;
+    
+    @RequestMapping(method = RequestMethod.GET)
+    public ModelAndView MsIframeMapper() throws Exception {
+        ModelAndView mv = new ModelAndView("msiframe");
+        mv.addObject("defaultContext", env.getProperty("msIframe.defaultContext"));
+        return mv;
+    }
+}

--- a/web/src/main/webapp/WEB-INF/msIframe-servlet.xml
+++ b/web/src/main/webapp/WEB-INF/msIframe-servlet.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:aop="http://www.springframework.org/schema/aop"
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xmlns:mvc="http://www.springframework.org/schema/mvc"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:security="http://www.springframework.org/schema/security"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
+       http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
+       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+       http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd">
+    <security:global-method-security secured-annotations="enabled" />
+    <mvc:annotation-driven/>
+    <context:component-scan base-package="fr.lepuyenvelay.msiframe" />
+    <!-- TODO: remove these duplucations -->
+    <context:property-placeholder location="classpath:mapstore.properties,file:${datadir.location:}/mapstore.properties" ignore-resource-not-found="true"/>
+    <bean id="viewResolver" class="org.springframework.web.servlet.view.InternalResourceViewResolver">
+      <property name="prefix">
+        <value>/WEB-INF/views/jsp/</value>
+      </property>
+      <property name="suffix">
+        <value>.jsp</value>
+      </property>
+    </bean>
+</beans>

--- a/web/src/main/webapp/WEB-INF/views/jsp/msiframe.jsp
+++ b/web/src/main/webapp/WEB-INF/views/jsp/msiframe.jsp
@@ -1,0 +1,265 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" isELIgnored="false" pageEncoding="UTF-8"%>
+<%@taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>Redirection vers Mapstore</title>
+  <style type="text/css">
+    html, body {
+      height: 100%;
+      margin:  0;
+    }
+    
+    #wrapper {
+      text-align: center;
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      -webkit-transform: translate(-50%, -50%);
+      transform: translate(-50%, -50%);
+      font-family: 'Courier New', monospace;
+    }
+    
+    #error {
+      display: none;
+      border: 1px solid;
+      margin: 10px 0px;
+      padding: 15px 10px 15px 50px;
+      background-repeat: no-repeat;
+      background-position: 10px center;
+      color: #D8000C;
+      background-color: #FFBABA;
+    }
+    
+    .lds-facebook {
+      display: inline-block;
+      position: relative;
+      width: 80px;
+      height: 80px;
+    }
+    .lds-facebook div {
+      display: inline-block;
+      position: absolute;
+      left: 8px;
+      width: 16px;
+      background: #fcf;
+      animation: lds-facebook 1.2s cubic-bezier(0, 0.5, 0.5, 1) infinite;
+    }
+    .lds-facebook div:nth-child(1) {
+      left: 8px;
+      animation-delay: -0.24s;
+    }
+    .lds-facebook div:nth-child(2) {
+      left: 32px;
+      animation-delay: -0.12s;
+    }
+    .lds-facebook div:nth-child(3) {
+      left: 56px;
+      animation-delay: 0;
+    }
+    @keyframes lds-facebook {
+      0% {
+        top: 8px;
+        height: 64px;
+      }
+      50%, 100% {
+        top: 24px;
+        height: 32px;
+      }
+    }
+  </style>
+  <script type="text/javascript">
+    function sendErrorsMessage(message) {
+      document.getElementById("load").style.display = "none";
+      document.getElementById("error").innerHTML = message;
+      document.getElementById("error").style.display = "block";
+    };
+    
+    function redirectPost(url, data) {
+      var form = document.createElement('form');
+      document.body.appendChild(form);
+      form.method = 'post';
+      form.action = url;
+      for (var name in data) {
+        var input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = name;
+        input.value = data[name];
+        form.appendChild(input);
+      }
+      form.submit();
+    };
+    
+    var baseUrl = "/mapstore/";
+    
+    <c:choose>
+        <c:when test="${not empty defaultContext}">
+            var defaultContext = "${defaultContext}";
+        </c:when>
+        <c:otherwise>
+            var defaultContext = null;
+        </c:otherwise>
+    </c:choose>
+  </script>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="load">
+      <div class="lds-facebook"><div></div><div></div><div></div></div>
+      <p>Chargement...</p>
+    </div>
+    <div id="error"></div>
+  </div>
+  <script type="text/javascript">
+    //Init variables
+    var errorMessages = [];
+    var map = {};
+    map.layers = [];
+    var actions = [];
+  
+    var qd = {};
+    location.search.substr(1).split("&").forEach(function(item) {qd[item.split("=")[0]] = item.split("=")[1]});
+  
+    var contextUrl = null, mapContext = null, catalogsContext = null;
+    var urls = [];
+  
+    if( !qd.c ) {
+      if( defaultContext != null ) {
+        contextUrl = "../../#/context/"+defaultContext;
+        urls.push(baseUrl+"rest/geostore/misc/category/name/CONTEXT/resource/name/"+defaultContext);
+      } else {
+        contextUrl = "../../#/";
+        urls.push(baseUrl+"configs/config.json");
+        urls.push(baseUrl+"configs/localConfig.json");
+      }
+    } else if( qd.c.match(/[^a-zA-Z0-9]/) ) {
+      throw "Le nom de contexte fourni n'est pas valide !";
+    } else {
+      contextUrl = "../../#/context/"+qd.c;
+      urls.push(baseUrl+"rest/geostore/misc/category/name/CONTEXT/resource/name/"+qd.c);
+    }
+  
+    var requests = urls.map(function(url){
+      return fetch(url).then(function(response) {
+        if( response.url.endsWith(".json") ) {
+          return response.json();
+        }
+        return response.text();
+      });
+    });
+  
+    Promise.all(requests).then((results) => {
+      results.forEach(response => {
+        if( typeof response == "string" ) {
+          let xml = new window.DOMParser().parseFromString(response, "text/xml");
+          let context = JSON.parse(xml.querySelector("data data").innerHTML);
+          mapContext = context.mapConfig.map;
+          catalogsContext = context.mapConfig.catalogServices;
+        } else if( response.map ) {
+          mapContext = response.map;
+        } else if( response.initialState.defaultState.catalog.default ) {
+          catalogsContext = response.initialState.defaultState.catalog.default;
+        } else {
+          // Error !
+          throw "Unknown fetched file format !";
+        }
+      });
+      
+      if( !mapContext || !catalogsContext || !catalogsContext.selectedService || !catalogsContext.services ) {
+        throw "Missing configuration element(s) !";
+      }
+      
+      var defaultCatalog = catalogsContext.selectedService;
+      var catalogsList = catalogsContext.services;
+
+      // Retrieving background layers
+      var backgroundsLayers = [];
+      mapContext.layers.forEach(l => {
+        if( l.group == "background" ) backgroundsLayers.push(l);
+      });
+
+      // Get x and y
+      if( !isNaN(parseFloat(qd.x)) && !isNaN(parseFloat(qd.y)) ) {
+        map.center = {x: parseFloat(qd.x), y: parseFloat(qd.y), crs: mapContext.projection};
+      } else if( qd.x || qd.y ) {
+        throw "The x or y values are invalid ! (Only numbers)";
+      }
+
+      // Retrieve zoom
+      if( !isNaN(parseInt(qd.z)) ) {
+        map.zoom = parseInt(qd.z);
+      } else if( qd.z ) {
+        throw "The z value is invalid ! (Only number)";
+      }
+
+      // Retrieve background to select
+      if( !isNaN(parseInt(qd.lb)) ) {
+        if( parseInt(qd.lb) > backgroundsLayers.length ) {
+          throw "The background number (lb) is invalid ! Maximum : "+backgroundsLayers.length+".";
+        }
+    
+        backgroundsLayers.forEach((bg,index) => {
+          if( index == parseInt(qd.lb) ) {
+            bg.visibility = true;
+          } else {
+            bg.visibility = false;
+          }
+          map.layers.push(bg);
+        });
+      } else if( qd.lb ) {
+        throw "The lb value is invalid ! (Only number)";
+      }
+
+      // Retrieve layers to load
+      if( qd.layers ) {
+        var layers = qd.layers.split(',');
+        layers.forEach(l => {
+          let params = l.split('*');
+          let layer = {};
+          layer.title = params[0];
+          layer.name = params[0];
+          var catalog;
+          if(params.length>1 && params[1]) {
+            catalog = catalogsList[params[1]];
+            if( !catalog ) {
+              throw "The catalog id is invalid ! No corresponding catalog in context.";
+            }
+          } else {
+            catalog = catalogsList[defaultCatalog];
+          }
+          layer.type = catalog.type;
+          layer.url = catalog.url;
+          layer.visibility = true;
+    
+          if(params.length>2 && params[2]) {
+            layer.style = params[2];
+          }
+    
+          if(params.length>3 && params[3]) {
+            layer.params = {};
+            layer.params.cql_filter = decodeURIComponent(params[3]);
+          }
+    
+          map.layers.push(layer);
+        });
+      }
+
+      // Retrieving search param
+      if( qd.s ) {
+        var explode = qd.s.split('*');
+        if( explode.length == 2 ) {
+          let action = {type: "SEARCH:SEARCH_WITH_FILTER", layer: explode[0], cql_filter: decodeURIComponent(explode[1])};
+          actions.push(action);
+        }
+      }
+    
+      var postParameters = {version: 2, map: map};
+      redirectPost(baseUrl+"rest/config/setParams", {map: JSON.stringify(postParameters), page: contextUrl, actions: JSON.stringify(actions)});
+    }).catch(function(err) {
+      console.log(err);
+      sendErrorsMessage("Error retrieving context's configuration : "+err);
+    });
+  </script>
+</body>
+</html>

--- a/web/src/main/webapp/WEB-INF/web.xml
+++ b/web/src/main/webapp/WEB-INF/web.xml
@@ -123,6 +123,16 @@
       <servlet-name>mapfish.print</servlet-name>
       <url-pattern>/pdf/*</url-pattern>
     </servlet-mapping>
+    
+    <!-- MsIframe -->
+    <servlet>
+        <servlet-name>msIframe</servlet-name>
+        <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>msIframe</servlet-name>
+        <url-pattern>/msiframe/*</url-pattern>
+    </servlet-mapping>
 
 	<!-- Default page to serve -->
 	<welcome-file-list>


### PR DESCRIPTION
Following https://github.com/georchestra/mapstore2-georchestra/issues/476

As explained in our last call, I think this still the better alternative.

The API documentation is available here : https://gitlab.agglo-lepuyenvelay.fr/jusabatier/msiframe/-/blob/master/README.md

This way it's only added to the Georchestra's version as you said me that you don't want maintain it for Mapstore.

I still have some questions : 

- Is the setParams (POST) bugued on master ? 

When I tested, I redirect to it but it always redirect to : `/mapstore/#/viewer/openlayers/config?queryParamsID=###` even if I provide a page parameter.

**Edit : I investigated and found out that it may be due to my environment log level (DEBUG).
In Spring 5.1, 5.2 and probably 5.3 (the MS version), request logs can flush the request content for form-urlencoded content types and so the controller can't get it. (cf. https://github.com/spring-projects/spring-framework/issues/22985)
I will test Monday with WARN logging level and it may correct this bug.**


- Is `/mapstore/#/viewer/openlayers/config` based on the same configs files as `/mapstore/#/` ? (config.json & localConfig.json)