### PR TITLE
Include Header plugin on a context page by default

### DIFF
--- a/configs/localConfig.json
+++ b/configs/localConfig.json
@@ -1061,6 +1061,9 @@
               "containerPosition": "header"
             }
           }
+        ],
+        "context": [
+          "Header"
         ]
     }
 }


### PR DESCRIPTION
Context page have an independent key in localConfig to enlist plugins that should be loaded on context viewer by default.
This default list should have "Header" plugin because it's not configurable in context creation/edit wizard and can't be added or removed there.