### PR TITLE
specify that for releases the MapStore submodule should be updated to the latest commit on the tracked stable branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ of the corresponding stable MapStore branch: the first line of the file indicate
 second the corresponding MapStore stable branch name used as dependency.
 
 Given a stable branch in mapstore2-georchestra, further minor releases of the same series (e.g. `2022.02`) are delivered from it (e.g. `2022.02.01-geOrchestra`).
-Even if it can be recommended, the MapStore submodule revision can be updated as well or not necessarily according to the project needs.
+Before each release or release candidate and in order to benefit from other bugfixes and feature backports, the MapStore submodule should be updated to the latest
+commit in the MapStore stable branch tracked by mapstore2-georchestra.
 At each release or release candidate the first line of the version.txt is updated with the tag name and restored to the previous version after the tag generation.
 
 All the releases are first delivered as release candidates, turned into release after acceptance.


### PR DESCRIPTION
as discussed in a meeting this morning with @catmorales and @jusabatier , we feel that it'd be better to enforce that rule for each release/release candidate. Sure, It calls for some testing, but there shouldn't be regressions from bugfixes, and this way we're more aligned with the stable branches of MapStore.

that topic was discussed in https://github.com/georchestra/mapstore2-georchestra/issues/573#issuecomment-1348680341 too but the stable update to MS 2022.02.02 (geosolutions-it/MapStore2@814ac152) was forgotten/missed when publishing the final https://github.com/georchestra/mapstore2-georchestra/releases/tag/2022.02.00-geOrchestra release which ships with geosolutions-it/MapStore2@15c079322f4ce44f73f957bd145a1bf209c695f2

Thus, we lack some bugfixes from https://github.com/geosolutions-it/MapStore2/blob/2022.02.xx/CHANGELOG.md#20220201-2022-11-16 and all the commits that happened for https://github.com/geosolutions-it/MapStore2/blob/2022.02.xx/CHANGELOG.md#20220202-2022-12-13 ...