### PR TITLE
exclude org.apache.cxf.Logger coming from geostore-webapp (fixes #586)

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -389,6 +389,7 @@
                 WEB-INF/lib/slf4j-api-1.5*.jar,
                 WEB-INF/lib/slf4j-log4j12-1.5*.jar,
                 WEB-INF/lib/spring-tx-5.2.15*.jar,
+                WEB-INF/classes/META-INF/cxf/org.apache.cxf.Logger,
                 WEB-INF/classes/geostore-datasource-ovr.properties,
                 WEB-INF/classes/geostore-ovr.properties
           </packagingExcludes>


### PR DESCRIPTION
it results in super verbose logging of REST queries on stderr when using the resulting WAR

thanks @pierrejego for the help :)