### PR TITLE
Change proxy url path to root

### DIFF
--- a/configs/localConfig.json
+++ b/configs/localConfig.json
@@ -1,6 +1,6 @@
 {
     "proxyUrl": {
-        "url": "proxy/?url=",
+        "url": "/proxy/?url=",
         "useCORS": [
           "https://georchestra.geo-solutions.it"
         ],


### PR DESCRIPTION
This PR changes proxy requests to be sent from the root path `https://[mygeorchestra]/` instead of `https://[mygeorchestra]/mapstore/`

When trying to use an external layer (3dtiles in the occasion) via the proxy I stumbled over the fact that requests to the layer sent from `https://[mygeorchestra]/mapstore/` are blocked by the georchestra security proxy.

Wondering if anybody has already successfully used the proxy with the current url within georchestra. If so, please correct me, I might be missing something.