### PR TITLE
#378 - Style overrides removed

### DIFF
--- a/themes/default/georchestra.less
+++ b/themes/default/georchestra.less
@@ -6,15 +6,6 @@
         display: inline-block;
     }
 }
-/* FIXES FOR CONTEXT CREATOR LAYOUT TOOLBAR AND BACKGROUND */
-#page-context-creator .mapToolbar {
-    bottom: 120px !important;
-}
-
-#page-context-creator .background-plugin-position {
-    bottom: 120px !important;
-}
-/* END OF FIXES FOR CONTEXT CREATOR LAYOUT TOOLBAR AND BACKGROUND */
 #georchestra-notallowed {
     position: absolute;
     width: 100%;

--- a/themes/default/header.less
+++ b/themes/default/header.less
@@ -9,37 +9,6 @@
 }
 
 /*
- * Bottom tools
- * Bottom tools have absolute position by default.
- * Anyway the bottom position to shift from the feature grid is % of view, not div
- * So this fixed position makes the position of the tools to be relative to the window too
- * and then also the percentage is relative to the same.
- */
-@geo-bottom-tools-position-fixed: fixed;
-@geo-bottom-tools-position-absolute: absolute;
-.background-plugin-position {
-    position: @geo-bottom-tools-position-fixed;
-}
-.mapToolbar {
-    position: @geo-bottom-tools-position-fixed;
-}
-.timeline-plugin {
-    position: @geo-bottom-tools-position-fixed!important;
-}
-// To fix overlap of bottom tools of map viewer in a modal
-.map-editor-modal-body {
-    .background-plugin-position {
-        position: @geo-bottom-tools-position-absolute;
-    }
-    .mapToolbar {
-        position: @geo-bottom-tools-position-absolute;
-    }
-    .timeline-plugin {
-        position: @geo-bottom-tools-position-absolute;
-    }
-}
-
-/*
  * CSS Used in geo-node integration, not yet used
  *
 .btn-group-vertical > .btn:first-child:not(:last-child){


### PR DESCRIPTION
### Description
This PR removes previously used overriden to position map toolbar, background selector and timline toolbar as these are not required anymore

### Issue
- #378 

### Screenshots
**Map/context viewer**
<img width="1983" alt="image" src="https://github.com/georchestra/mapstore2-georchestra/assets/26929983/4f5df232-5643-4f49-b41b-0cc0aa588587">

**Context-creator**
<img width="1984" alt="Screenshot 2023-07-03 at 5 46 19 PM" src="https://github.com/georchestra/mapstore2-georchestra/assets/26929983/14805c7e-3e30-4bf2-9b77-69e95fa6ef7e">

**Geostory - Map viewer modal**
<img width="1975" alt="Screenshot 2023-07-03 at 5 48 02 PM" src="https://github.com/georchestra/mapstore2-georchestra/assets/26929983/be0d7078-4a73-4694-bbf0-7830dfd0cc8e">
