### PR TITLE
docker - provide unzipped war

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
+FROM alpine:latest as alpine
+RUN apk --update add unzip && rm -rf /var/cache/apk/*
+WORKDIR /tmp
+COPY docker/MapStore-*.war mapstore.war
+RUN unzip mapstore.war -d mapstore
+
+
 FROM tomcat:9-jdk11-openjdk
 MAINTAINER geosolutions<info@geo-solutions.it>
 
@@ -11,8 +18,8 @@ RUN if [ "$TOMCAT_EXTRAS" = false ]; then \
       find "${CATALINA_BASE}/webapps/" -delete; \
     fi
 
-# Add war files to be deployed
-COPY docker/*.war "${CATALINA_BASE}/webapps/mapstore.war"
+# Add application from first stage
+COPY --from=alpine /tmp/mapstore "${CATALINA_BASE}/webapps/mapstore"
 
 # Geostore externalization template. Disabled by default
 # COPY docker/geostore-datasource-ovr.properties "${CATALINA_BASE}/conf/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM alpine:latest as alpine
-RUN apk --update add unzip && rm -rf /var/cache/apk/*
+FROM alpine:latest as extractwar
+RUN apk --no-cache add unzip
 WORKDIR /tmp
 COPY docker/MapStore-*.war mapstore.war
 RUN unzip mapstore.war -d mapstore
@@ -19,7 +19,7 @@ RUN if [ "$TOMCAT_EXTRAS" = false ]; then \
     fi
 
 # Add application from first stage
-COPY --from=alpine /tmp/mapstore "${CATALINA_BASE}/webapps/mapstore"
+COPY --from=extractwar /tmp/mapstore "${CATALINA_BASE}/webapps/mapstore"
 
 # Geostore externalization template. Disabled by default
 # COPY docker/geostore-datasource-ovr.properties "${CATALINA_BASE}/conf/"


### PR DESCRIPTION
geOrchestra docker images are provided with unzipped webapps. 
The current PR aligns MapStore-georchestra docker image with the other ones.

Example direct benefit - custom themes are easier to implement using docker:
```
- ./themes:/usr/local/tomcat/webapps/mapstore/dist/themes
```

A multi stage build is used to reduce the final image size - it does not have to embed the original war file.