### PR TITLE
#638: Redirect to requested resource on login

### DIFF
--- a/js/epics/login.js
+++ b/js/epics/login.js
@@ -7,21 +7,38 @@
  */
 import {Observable} from "rxjs";
 import { LOGIN_REQUIRED } from '@mapstore/actions/security';
+import { LOCATION_CHANGE } from 'connected-react-router';
 
-const goToLoginPage = () => {
-    window.location.replace('/?login');
+const CAS_REDIRECT_PATH = 'casRedirectPath';
+const goToPage = (path) => {
+    window.location.replace(path);
 };
 const redirectToLoginPage = (action$) =>
     action$.ofType(LOGIN_REQUIRED)
         .switchMap(() => {
-        /*
-            Note: After login the user is not redirected back to the same resource requested,
-            as CAS login currently doesn't support that
-        */
-            goToLoginPage();
+            window.localStorage.setItem(CAS_REDIRECT_PATH, window.location.hash);
+            /*
+                Note: After login, the user is not redirected back to the previously requested resource as the CAS skips the hash part.
+                Hence, the side effect is performed by `casRedirectOnLogin` epic to redirect back to the same resource requested
+            */
+            goToPage('/mapstore/?login');
+            return Observable.empty();
+        });
+
+const casRedirectOnLogin = (action$) =>
+    action$.ofType(LOCATION_CHANGE)
+        .filter(({payload} = {}) => payload?.location?.pathname === '/' && window.localStorage.getItem(CAS_REDIRECT_PATH))
+        .switchMap(() => {
+            const redirectPath = window.localStorage.getItem(CAS_REDIRECT_PATH);
+            /*
+                Once the redirection is performed, redirect path is removed
+            */
+            window.localStorage.removeItem(CAS_REDIRECT_PATH);
+            goToPage(redirectPath);
             return Observable.empty();
         });
 
 export default {
-    redirectToLoginPage
+    redirectToLoginPage,
+    casRedirectOnLogin
 };


### PR DESCRIPTION
### Description
This PR handle redirection after login when login redirection was performed programatically (due to unauthorized access to a resource and not logged in). Previously requested resource is saved to localstorage and upon successful redirection (after login) the saved localstorage value is cleared

### Issue
- https://github.com/georchestra/mapstore2-georchestra/issues/638#issuecomment-1670782515