### PR TITLE
Implement custom scripts for mapstore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ coverage/
 backend/.classpath
 backend/.project
 package-lock.json
+.idea/
+docker/*.war

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN if [ "$TOMCAT_EXTRAS" = false ]; then \
 
 # Add application from first stage
 COPY --from=extractwar /tmp/mapstore "${CATALINA_BASE}/webapps/mapstore"
+COPY georchestra-docker-scripts/ /
+
 
 # Geostore externalization template. Disabled by default
 # COPY docker/geostore-datasource-ovr.properties "${CATALINA_BASE}/conf/"
@@ -30,4 +32,7 @@ ENV JAVA_OPTS="${JAVA_OPTS} ${GEORCHESTRA_DATADIR_OPT}"
 # Set variable to better handle terminal commands
 ENV TERM xterm
 
+# Necessary to execute tomcat and custom scripts
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["catalina.sh", "run"]
 EXPOSE 8080

--- a/georchestra-docker-scripts/docker-entrypoint.d/100-execute-custom-scripts.sh
+++ b/georchestra-docker-scripts/docker-entrypoint.d/100-execute-custom-scripts.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Executing custom scripts located in CUSTOM_SCRIPTS_DIRECTORY if environment variable is set
+if [[ -z "${CUSTOM_SCRIPTS_DIRECTORY}" ]]; then
+  echo "[INFO] No CUSTOM_SCRIPTS_DIRECTORY env variable set"
+else
+  echo "[INFO] CUSTOM_SCRIPTS_DIRECTORY env variable set to ${CUSTOM_SCRIPTS_DIRECTORY}"
+  # Regex is needed in jetty9 images, but not alpine's ones.
+  run-parts -v "${CUSTOM_SCRIPTS_DIRECTORY}" --regex='.*'
+  echo "[INFO] End executing custom scripts"
+fi

--- a/georchestra-docker-scripts/docker-entrypoint.sh
+++ b/georchestra-docker-scripts/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+DIR=/docker-entrypoint.d
+
+if [[ -d "$DIR" ]]
+then
+  # Regex is needed to execute all kind of files, including sh files. Warning : --regex not available in alpine images.
+  /bin/run-parts --verbose "$DIR" --regex='.*'
+fi
+
+exec "$@"


### PR DESCRIPTION
# Custom scripts 

This PR adds the capability to run scripts at startup of the container.

It's a part of the georchestra PR :
- https://github.com/georchestra/georchestra/pull/4083

Soving issue : 
- https://github.com/georchestra/georchestra/issues/4030

## How-to

Set  `CUSTOM_SCRIPTS_DIRECTORY` environment variable to point to a valid volume.
Set a volume with scripts to execute.


Example :
```
 mapstore:
    image: georchestra/mapstore:latest
    ...
    volumes:
      - georchestra_datadir:/etc/georchestra
    environment:
      - CUSTOM_SCRIPTS_DIRECTORY=/etc/georchestra/mapstore/scripts
```
