### PR TITLE
Favicon location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,6 @@ backend/.classpath
 backend/.project
 package-lock.json
 .idea/
+*.iml
+.nvmrc
 docker/*.war

--- a/api.html
+++ b/api.html
@@ -7,7 +7,7 @@
         <title>geOrchestra</title>
         <link rel="preconnect" href="https://fonts.gstatic.com">
         <link href="https://fonts.googleapis.com/css2?family=Noto+Sans&display=swap" rel="stylesheet">
-        <link rel="shortcut icon" type="image/png" href="https://cdn.jslibs.mapstore2.geo-solutions.it/leaflet/favicon.ico" />
+        <link rel="shortcut icon" type="image/png" href="/favicon.ico" />
         <!--script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.10/proj4.js"></script-->
         <style>
         #container {

--- a/apiTemplate.html
+++ b/apiTemplate.html
@@ -7,7 +7,7 @@
         <title>geOrchestra</title>
         <link rel="preconnect" href="https://fonts.gstatic.com">
         <link href="https://fonts.googleapis.com/css2?family=Noto+Sans&display=swap" rel="stylesheet">
-        <link rel="shortcut icon" type="image/png" href="https://cdn.jslibs.mapstore2.geo-solutions.it/leaflet/favicon.ico" />
+        <link rel="shortcut icon" type="image/png" href="/favicon.ico" />
         <!--script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.10/proj4.js"></script-->
         <style>
         #container {

--- a/embedded.html
+++ b/embedded.html
@@ -103,7 +103,7 @@
         <link rel="preconnect" href="https://fonts.gstatic.com">
         <link href="https://fonts.googleapis.com/css2?family=Noto+Sans&display=swap" rel="stylesheet">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" />
-        <link rel="shortcut icon" type="image/png" href="https://cdn.jslibs.mapstore2.geo-solutions.it/leaflet/favicon.ico" />
+        <link rel="shortcut icon" type="image/png" href="/favicon.ico" />
         <!--script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.10/proj4.js"></script-->
     </head>
     <body>

--- a/embeddedTemplate.html
+++ b/embeddedTemplate.html
@@ -103,7 +103,7 @@
         <link rel="preconnect" href="https://fonts.gstatic.com">
         <link href="https://fonts.googleapis.com/css2?family=Noto+Sans&display=swap" rel="stylesheet">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" />
-        <link rel="shortcut icon" type="image/png" href="https://cdn.jslibs.mapstore2.geo-solutions.it/leaflet/favicon.ico" />
+        <link rel="shortcut icon" type="image/png" href="/favicon.ico" />
         <!--script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.10/proj4.js"></script-->
         <script async type="text/javascript" src="https://unpkg.com/bowser@2.7.0/es5.js" onload="checkBrowser()"></script>
         <script type="text/javascript">

--- a/geostory-embedded-template.html
+++ b/geostory-embedded-template.html
@@ -94,7 +94,7 @@
     </style>
     <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans&display=swap" rel="stylesheet">
-    <link rel="shortcut icon" type="image/png" href="https://cdn.jslibs.mapstore2.geo-solutions.it/leaflet/favicon.ico" />
+    <link rel="shortcut icon" type="image/png" href="/favicon.ico" />
     <!--script src="https://maps.google.com/maps/api/js?v=3"></script-->
     <script async type="text/javascript" src="https://unpkg.com/bowser@2.7.0/es5.js" onload="checkBrowser()"></script>
     <script type="text/javascript">

--- a/geostory-embedded.html
+++ b/geostory-embedded.html
@@ -94,7 +94,7 @@
     </style>
     <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans&display=swap" rel="stylesheet">
-    <link rel="shortcut icon" type="image/png" href="https://cdn.jslibs.mapstore2.geo-solutions.it/leaflet/favicon.ico" />
+    <link rel="shortcut icon" type="image/png" href="/favicon.ico" />
     <!--script src="https://maps.google.com/maps/api/js?v=3"></script-->
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
         <link rel="preconnect" href="https://fonts.gstatic.com">
         <link href="https://fonts.googleapis.com/css2?family=Noto+Sans&display=swap" rel="stylesheet">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" />
-        <link rel="shortcut icon" type="image/png" href="https://cdn.jslibs.mapstore2.geo-solutions.it/leaflet/favicon.ico" />
+        <link rel="shortcut icon" type="image/png" href="/favicon.ico" />
         <!--script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.10/proj4.js"></script-->
         <!--<script src="https://www.mapquestapi.com/sdk/leaflet/v2.2/mq-map.js?key=__API_KEY_MAPQUEST__"></script>-->
 

--- a/indexTemplate.html
+++ b/indexTemplate.html
@@ -117,7 +117,7 @@
       <link rel="preconnect" href="https://fonts.gstatic.com">
       <link href="https://fonts.googleapis.com/css2?family=Noto+Sans&display=swap" rel="stylesheet">
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" />
-      <link rel="shortcut icon" type="image/png" href="https://cdn.jslibs.mapstore2.geo-solutions.it/leaflet/favicon.ico" />
+      <link rel="shortcut icon" type="image/png" href="/favicon.ico" />
       <script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.10/proj4.js"></script>
       <script async type="text/javascript" src="https://unpkg.com/bowser@2.7.0/es5.js" onload="checkBrowser()"></script>
       <script type="text/javascript">


### PR DESCRIPTION
# Favicon location

This PR is used to change favicon to point to `/favicon.ico` url.

This is supposed to be the default location for geOrchestra's favicon.

Resolving : 
- https://github.com/georchestra/georchestra/issues/4087

## Altering default behavior.

In order to change default location, we can implement it with a custom script, modyfing `/favicon.ico` infollowing html files to the new location using  a tool like `sed`. 

Files to change : 
```
# /usr/local/tomcat
./webapps/mapstore/embedded.html
./webapps/mapstore/api.html
./webapps/mapstore/embeddedTemplate.html
./webapps/mapstore/geostory-embedded.html
./webapps/mapstore/index.html
./webapps/mapstore/dist/embedded.html
./webapps/mapstore/dist/geOrchestra.js
./webapps/mapstore/dist/geostory-embedded.html
./webapps/mapstore/dist/index.html
./webapps/mapstore/indexTemplate.html
./webapps/mapstore/geostory-embedded-template.html
./webapps/mapstore/apiTemplate.html
```