### PR TITLE
fix build with java 17

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -91,8 +91,8 @@
     <!--  mockito -->
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.9.5</version>
+      <artifactId>mockito-core</artifactId>
+      <version>4.0.0</version>
       <scope>test</scope>
     </dependency>
     <!-- servlet -->
@@ -386,7 +386,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.1.1</version>
+        <version>3.4.0</version>
         <configuration>
           <packagingExcludes>
                 WEB-INF/lib/commons-codec-1.2.jar,


### PR DESCRIPTION
update:
- maven-war-plugin to 3.4.0
- mockito-core to 4.0.0

with geosolutions-it/MapStore2#9851 this allows me to build mapstore2-georchestra with java17, which is the default java version on debian 12.