### PR TITLE
fix logging configuration path by adding a missing / (#662)

### DIFF
--- a/web/src/main/resources/log4j2.component.properties
+++ b/web/src/main/resources/log4j2.component.properties
@@ -1,1 +1,1 @@
-log4j.configurationFile=classpath:log4j2.properties,${sys:georchestra.datadir}mapstore/log4j2.properties
+log4j.configurationFile=${sys:georchestra.datadir}/mapstore/log4j2.properties


### PR DESCRIPTION
only point at log4j2.properties in the georchestra datadir, apparently that property doesn't have the support for config path priorities

fixes #662