### PR TITLE
set sec-username/sec-roles in webpack proxy config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,7 +44,10 @@ module.exports = require("./MapStore2/build/buildConfig")({
             target: `${DEV_PROTOCOL}://${DEV_HOST}/mapstore`,
             secure: false,
             headers: {
-                host: `${DEV_HOST}`
+                host: `${DEV_HOST}`,
+                // change those for your local instance
+                "sec-username": 'testadmin',
+                "sec-roles": 'ROLE_MAPSTORE_ADMIN'
             }
         },
         "/pdf": {
@@ -81,6 +84,23 @@ module.exports = require("./MapStore2/build/buildConfig")({
             secure: false,
             headers: {
                 host: `${DEV_HOST}`
+            }
+        },
+        "/cas": {
+            target: `${DEV_PROTOCOL}://${DEV_HOST}`,
+            secure: false,
+            headers: {
+                host: `${DEV_HOST}`
+            }
+        },
+        "/whoami": {
+            target: `${DEV_PROTOCOL}://${DEV_HOST}`,
+            secure: false,
+            headers: {
+                host: `${DEV_HOST}`,
+                // change those for your local instance
+                "sec-username": 'testadmin',
+                "sec-roles": 'ROLE_MAPSTORE_ADMIN'
             }
         }
     }}


### PR DESCRIPTION
allows testing features restricted to connected users

/cas correctly proxies to cas, but /whoami still replies `{"GeorchestraUser":null}` so the header shows the login button.

@f-necas : using:
```
-const DEV_HOST = "localhost:8080";
+const DEV_HOST = "georchestra.example.org:8180";
```
the page header still doesnt show me the logged in button, while mapstore itself shows me the plugins restricted to an admin user (eg save/delete/etc etc) so the authenticated requests to `/rest` work with `sec-username`/`sec-roles` only.

what were the headers necessary for `/whoami` to correctly find the user ? against a throwaway instance i can't figure that out...

```
curl -H sec-username:testadmin -H sec-proxy:true -H sec-roles:ROLE_MAPSTORE_ADMIN -H sec-org:C2C \
       -H 'sec-orgname: Test Org' http://georchestra.example.org:8180/whoami
{"GeorchestraUser":null}
```