### PR TITLE
Remove proj4.js to use local implementation, also add backport

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,29 @@
+name: Automatic backport action
+
+on:
+  pull_request_target:
+    types: ["closed", "labeled"]
+
+permissions:
+  contents: write # so it can comment
+  pull-requests: write # so it can create pull requests
+
+jobs:
+  backport:
+    name: Backport PR
+    if: github.event.pull_request.merged == true && !(contains(github.event.pull_request.labels.*.name, 'backport'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Backport Action
+        uses: sqren/backport-github-action@v9.3.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          auto_backport_label_prefix: backport-to-
+
+      - name: Info log
+        if: ${{ success() }}
+        run: cat ~/.backport/backport.info.log
+
+      - name: Debug log
+        if: ${{ failure() }}
+        run: cat ~/.backport/backport.debug.log

--- a/indexTemplate.html
+++ b/indexTemplate.html
@@ -121,7 +121,6 @@
                 src: local('Noto Sans'), local('NotoSans-Regular'), url(assets/fonts/NotoSans.ttf) format('truetype');
           }
       </style>
-      <script src="assets/js/proj4.js"></script>
       <script src="https://unpkg.com/bowser@2.7.0/es5.js"
               async integrity="sha384-CWiXbo5RNu6nv9tiCWA2y1DQKjEQDDH+yFQga1FytuIZjOTcVr+4ojw2S2lShj/d" crossorigin="anonymous"
               onload="checkBrowser()"></script>


### PR DESCRIPTION
Closes https://github.com/georchestra/mapstore2-georchestra/issues/728

Remove proj4.js to use local implementation
Temporary keep es5.js with cdn 

Add backport bot to use label for backport.