### PR TITLE
chore: add required java parameters + fix JAVA_OPTIONS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ MAINTAINER geosolutions<info@geo-solutions.it>
 RUN mkdir -p /docker-entrypoint.d
 # Tomcat specific options
 ENV CATALINA_BASE "$CATALINA_HOME"
-ENV JAVA_OPTS="${JAVA_OPTS} -XX:MaxRAMPercentage=80 -XX:+UseParallelGC ${JAVA_OPTIONS}"
+ENV JAVA_OPTS="${JAVA_OPTS} -XX:MaxRAMPercentage=80 -XX:+UseParallelGC"
 
 # Optionally remove Tomcat manager, docs, and examples
 ARG TOMCAT_EXTRAS=false
@@ -37,7 +37,9 @@ USER tomcat
 # COPY docker/geostore-datasource-ovr.properties "${CATALINA_BASE}/conf/"
 # ARG GEOSTORE_OVR_OPT=""
 ARG GEORCHESTRA_DATADIR_OPT="-Dgeorchestra.datadir=/etc/georchestra"
-ENV JAVA_OPTS="${JAVA_OPTS} ${GEORCHESTRA_DATADIR_OPT}"
+# geOrchestra required parameters for mapstore-geOrchestra to function properly
+ARG GEORCHESTRA_REQUIRED_OPTS="-DPRINT_BASE_URL=pdf -Dgeorchestra.extensions=/mnt/mapstore_extensions"
+ENV JAVA_OPTS="${JAVA_OPTS} ${GEORCHESTRA_DATADIR_OPT} ${GEORCHESTRA_REQUIRED_OPTS}"
 
 # Set variable to better handle terminal commands
 ENV TERM xterm

--- a/georchestra-docker-scripts/99-apply-java-options.sh
+++ b/georchestra-docker-scripts/99-apply-java-options.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# JAVA_OPTIONS gives the ability to add more parameters to JAVA_OPTS at runtime.
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Check if JAVA_OPTIONS is set and not empty
+if [ -n "$JAVA_OPTIONS" ]; then
+  echo "Applying runtime JAVA_OPTIONS: $JAVA_OPTIONS"
+  # Append JAVA_OPTIONS to JAVA_OPTS
+  export JAVA_OPTS="${JAVA_OPTS} $JAVA_OPTIONS"
+fi


### PR DESCRIPTION
### First part

In https://github.com/georchestra/mapstore2-georchestra/pull/731, @jusabatier tried to add the support for JAVA_OPTIONS. JAVA_OPTIONS is a variable for adding more parameters to JAVA_OPTS at runtime.

In this PR, this fixes this ability which didn't work because in https://github.com/georchestra/mapstore2-georchestra/pull/731, JAVA_OPTIONS was only evaluated at Docker build. There is now a script that appends JAVA_OPTIONS to JAVA_OPTS at runtime.

### Second part

Add these standard java parameters that are used in all of our mapstore install and are required for mapstore-geOrchestra to function well :
```
-DPRINT_BASE_URL=pdf -Dgeorchestra.extensions=/mnt/mapstore_extensions
```

This will avoid having to pass these parameters in [docker compose](https://github.com/georchestra/docker/blob/3e7e3b0ff8786cc073e4e2ea9a8f3d11ea6c869b/docker-compose.yml#L219) or [helm chart](https://github.com/georchestra/helm-georchestra/blob/6d85dd04900976b09283e80d172a8a8012c4d045/templates/mapstore/mapstore-deployment.yaml#L53), guaranteeing that these parameters will always be there and work.

This is similar to what I suggested in https://github.com/georchestra/georchestra-gateway/pull/147