### PR TITLE
fix: bump docker to 9-jdk

### DIFF
--- a/.github/workflows/mapstore.yml
+++ b/.github/workflows/mapstore.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: "checking out"
       uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /tmp
 COPY docker/MapStore-*.war mapstore.war
 RUN unzip mapstore.war -d mapstore
 
-FROM tomcat:9-jdk11-openjdk
+#9-jdk11 uses temurin 11.0.27 and not openjdk 11.0.16
+FROM tomcat:9-jdk11
 MAINTAINER geosolutions<info@geo-solutions.it>
 
 RUN mkdir -p /docker-entrypoint.d


### PR DESCRIPTION
Solves Cgroup2 problem with. 

JDK uses temurin now