### PR TITLE
Applied styles to make the header, menus and windows to avoid conflicts

### DIFF
--- a/themes/default/georchestra.less
+++ b/themes/default/georchestra.less
@@ -44,9 +44,17 @@
 #ms-brand-navbar {
     z-index: 1900;
 }
+// makes the header always
 geor-header {
     z-index: 2000;
 }
+#page-maps geor-header, div#page-manager geor-header {
+    position: relative;
+}
+// hides
 ._ms2_init_text {
     display: none !important;
+}
+.mapstore-print-panel.modal-dialog {
+    z-index: 2000 !important;
 }


### PR DESCRIPTION
This should fix:
- Menu and header conflict (on home, manager)
<img width="227" height="199" alt="image" src="https://github.com/user-attachments/assets/bad90949-7b2e-4dbd-a848-a379e9b08094" />
- print window overlapping issues (on map viewer)
<img width="930" height="289" alt="image" src="https://github.com/user-attachments/assets/c0177796-23c8-48d9-839e-e1ce94ef16c7" />
