### PR TITLE
Update geostore-webapp version to 2.5-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <cargo.version>1.10.2</cargo.version>
         <!-- MapStore‑specific -->
         <mapstore-services.version>1.10-SNAPSHOT</mapstore-services.version>
-        <geostore-webapp.version>2.4.0</geostore-webapp.version>
+        <geostore-webapp.version>2.5-SNAPSHOT</geostore-webapp.version>
         <http_proxy.version>1.5.0</http_proxy.version>
         <print-lib.version>2.3.4</print-lib.version>
     </properties>


### PR DESCRIPTION
This PR aligns geostore to current development version to apply a fix that avoid a nullpointerexception in the login case.
This allows to test all the features (except favorites feature that need to be adapted).