### PR TITLE
Fix #756. Set correct configuration for Header plugin as default

### DIFF
--- a/configs/pluginsConfig.json
+++ b/configs/pluginsConfig.json
@@ -27,9 +27,9 @@
           }
         }
       }
-    },{
+    }, {
       "name": "Header",
-      "cfg": {
+      "defaultConfig": {
         "containerPosition": "header"
       }
     },


### PR DESCRIPTION
This PR updates the `pluginsConfig.json` (responsible of context creation wizard items and defaults), the correct configuration as default.

Fix #756.