### PR TITLE
[Backport 2025.02.xx] Fix #756. Set correct configuration for Header plugin as default

### DIFF
--- a/configs/pluginsConfig.json
+++ b/configs/pluginsConfig.json
@@ -27,9 +27,9 @@
           }
         }
       }
-    },{
+    }, {
       "name": "Header",
-      "cfg": {
+      "defaultConfig": {
         "containerPosition": "header"
       }
     },


### PR DESCRIPTION
Fix #756 
Backport of #758 