### PR TITLE
install applicationContext-print.xml in the right subdir (fixes #761)

### DIFF
--- a/.github/workflows/mapstore.yml
+++ b/.github/workflows/mapstore.yml
@@ -65,7 +65,7 @@ jobs:
         ARTIFACTORY_USERNAME_REF: ${{ secrets.ARTIFACTORY_USERNAME }}
 
     - name: "debian package with Maven"
-      run: mvn -B package deb:package -pl web -PdebianPackage
+      run: mvn -B package deb:package -pl web -PdebianPackage,printing
 
     - name: "copy resulting deb"
       run: mkdir -p scratch && cp web/target/georchestra-mapstore*.deb scratch/georchestra-mapstore-${{ github.sha }}.deb

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -669,7 +669,7 @@
                                 <configuration>
                                 <overWrite>true</overWrite>
                                 <sourceFile>../MapStore2/java/printing/webapp/applicationContext-print.xml</sourceFile>
-                                <destinationFile>target/mapstore/WEB-INF/classes/applicationContext-print.xml</destinationFile>
+                                <destinationFile>target/${project.build.finalName}/WEB-INF/classes/applicationContext-print.xml</destinationFile>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
unbreaks printing when using -PdebianPackage, which sets finalName to mapstore-generic

with that, the print panel is back when the war is deployed from a debian package built with `-PdebianPackage,printing` (without printing profile, print-lib jar isnt shipped in the war)