### PR TITLE
Add tokenRefreshInterval to localConfig.json

### DIFF
--- a/configs/localConfig.json
+++ b/configs/localConfig.json
@@ -6,6 +6,7 @@
         ],
         "autoDetectCORS": true
     },
+    "tokenRefreshInterval":864000000,
     "geoStoreUrl": "rest/geostore/",
     "printUrl": "pdf/info.json",
     "bingApiKey": "AhuXBu7ipR1gNbBfXhtUAyCZ6rkC5PkWpxs2MnMRZ1ZupxQfivjLCch22ozKSCAn",


### PR DESCRIPTION
This configuration (documented [here](https://docs.mapstore.geosolutionsgroup.com/en/latest/developer-guide/integrations/auth/#configure-session-timeout)) increases the refresh token sync to 10 days.

Given that: 
 - when the user opens the page, the application checks the session validity anyway
 - When logout, the user is redirected to another application, so in fact the second opening of mapstore will revalidate the session

There are no other cases where the session renew is required, that can be handled by georchestra as well.
This ensures that the application do not disconnect automatically during a session fixing the following issues : 
- Fix https://github.com/georchestra/mapstore2-georchestra/issues/783
- Fix https://github.com/georchestra/mapstore2-georchestra/issues/774